### PR TITLE
Never swallow exceptions

### DIFF
--- a/sift/client.py
+++ b/sift/client.py
@@ -103,7 +103,7 @@ class Client(object):
             sift_logger.warn('Failed to track event: %s' % properties)
             sift_logger.warn(traceback.format_exception_only(type(e), e))
 
-            return e
+            raise
 
     def score(self, user_id, timeout = None):
         """Retrieves a user's fraud score from the Sift Science API.
@@ -135,7 +135,7 @@ class Client(object):
             sift_logger.warn('Failed to get score for user %s' % user_id)
             sift_logger.warn(traceback.format_exception_only(type(e), e))
 
-            return e
+            raise
 
     def label(self, user_id, properties, timeout = None):
         """Labels a user as either good or bad through the Sift Science API.


### PR DESCRIPTION
It's very bad form to swallow exceptions like this. With the return version, you'd have to handle errors like this:

``` python
score = client.score(user_id)
if isinstance(score, requests.exception.RequestException):
    pass  # error handling
elif score.is_ok():
    pass  # ok handling... we can't do this first, because score might not have an is_ok method
else:
    pass  # what exactly is happening here?
```

This is a quickfix, allowing you to handle it like this instead:

``` python
try:
    score = client.score(user_id)
    if score.is_ok():
        pass # handle ok
    else:
        pass # still not sure what happens here
except requests.Timeout:
     pass  # hey look! error handling!
```

One could go even further, and instead of having a request.is_ok, throwing some kind of SiftApiError which is a subclass of SiftError. This would simplify error handling even further. In that case it could look like this:

``` python
try:
    score = client.score(user_id)
except sift.SiftApiError:
    pass  # handle an api error. The exception has the error code and message as attributes
except sift.SiftError:
    pass  # handle a general error (probably input related)
except sift.Timeout:
    pass  # maybe retry or something. this is actually the requests exception
```

This would be a lot cleaner and more idiomatic.
