### PR TITLE
Fix Python 2.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "2.6"
   - "2.7"
   - "3.4"
 # command to install dependencies

--- a/sift/client.py
+++ b/sift/client.py
@@ -7,7 +7,7 @@ import logging
 import requests
 import traceback
 import sys
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
   import urllib
 else:
   import urllib.parse as urllib
@@ -44,7 +44,7 @@ class Client(object):
         self.api_key = api_key
         self.url = api_url + '/v%s' % version.API_VERSION
         self.timeout = timeout
-        if sys.version_info.major < 3:
+        if sys.version_info[0] < 3:
           self.UNICODE_STRING = basestring
         else:
           self.UNICODE_STRING = str

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -51,8 +51,7 @@ def response_with_data_header():
            }
 
 class TestSiftPythonClient(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
+    def setUp(self):
         self.test_key = 'a_fake_test_api_key'
         self.sift_client = sift.Client(self.test_key)
 

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -5,7 +5,7 @@ import sift
 import unittest
 import sys
 import requests.exceptions
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
   import urllib
 else:
   import urllib.parse as urllib
@@ -239,7 +239,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_unicode_string_parameter_support(self):
         # str is unicode in python 3, so no need to check as this was covered by other unit tests.
-        if sys.version_info.major < 3:
+        if sys.version_info[0] < 3:
             mock_response = mock.Mock()
             mock_response.content = '{"status": 0, "error_message": "OK"}'
             mock_response.json.return_value = json.loads(mock_response.content)


### PR DESCRIPTION
The code is not compatible with Python 2.6 and fails with:
```
>       if sys.version_info.major < 3:
E       AttributeError: 'tuple' object has no attribute 'major'
```
The reason is that Python 2.6 version_info has no `major` attribute. This fixes the problem. According to https://docs.python.org/2/library/sys.html#sys.version_info `sys.version_info[0] is equivalent to sys.version_info.major`