### PR TITLE
Add return_action parameter to track method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ except:
 setup(
     name='Sift',
     description='Python bindings for Sift Science\'s API',
-    version='1.1.2.4',  # NB: must be kept in sync with sift/version.py
+    version='1.1.2.5',  # NB: must be kept in sync with sift/version.py
     url='https://siftscience.com',
 
     author='Sift Science',

--- a/sift/client.py
+++ b/sift/client.py
@@ -67,6 +67,7 @@ class Client(object):
             properties,
             path=None,
             return_score=False,
+            return_action=False,
             timeout=None):
         """Track an event and associated properties to the Sift Science client.
         This call is blocking.  Check out https://siftscience.com/resources/references/events_api
@@ -77,11 +78,18 @@ class Client(object):
             event: The name of the event to send. This can either be a reserved
                 event name such as "$transaction" or "$create_order" or a custom event
                 name (that does not start with a $).
+
             properties: A dict of additional event-specific attributes to track
+
             return_score: Whether the API response should include a score for this
                  user (the score will be calculated using this event).  This feature must be
                  enabled for your account in order to use it.  Please contact
                  support@siftscience.com if you are interested in using this feature.
+
+            return_action: Whether the API response should include actions in the response. For
+                 more information on how this works, please visit the tutorial at:
+                 https://siftscience.com/resources/tutorials/formulas
+
         Returns:
             A requests.Response object if the track call succeeded, otherwise
             a subclass of requests.exceptions.RequestException indicating the
@@ -107,8 +115,13 @@ class Client(object):
 
         properties.update({'$api_key': self.api_key, '$type': event})
         params = {}
+
         if return_score:
             params.update({'return_score': return_score})
+
+        if return_action:
+            params.update({'return_action': return_action})
+
         try:
             response = requests.post(
                 path,

--- a/sift/client.py
+++ b/sift/client.py
@@ -70,7 +70,7 @@ class Client(object):
             return_action=False,
             timeout=None):
         """Track an event and associated properties to the Sift Science client.
-        This call is blocking.  Check out https://siftscience.com/resources/references/events_api
+        This call is blocking.  Check out https://siftscience.com/resources/references/events-api
         for more information on what types of events you can send and fields you can add to the
         properties parameter.
 

--- a/sift/version.py
+++ b/sift/version.py
@@ -1,3 +1,3 @@
 # NB: Be sure to keep in sync w/ setup.py
-VERSION = '1.1.2.4'
+VERSION = '1.1.2.5'
 API_VERSION = '203'


### PR DESCRIPTION
cc @jburnim 

Adds the `?return_action` query parameter to the `track` method to enable retrieving formulas and actions for the event.

Fixes https://github.com/SiftScience/sift-python/issues/27, but leaves the return_score method in place.
