### PR TITLE
mock is not a production requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
 # command to install dependencies
 install:
-  - "python setup.py install"
+  - pip install -e .[test]
 # command to run tests
 script:
-  - "PYTHONPATH=. python tests/client_test.py"
+  - python tests/client_test.py

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,12 @@ setup(
     packages=['sift'],
     install_requires=[
         "requests >= 0.14.1",
-        "mock >= 1.0.1",
     ],
+    extras_require={
+        'test': [
+            'mock >= 1.0.1',
+        ],
+    },
 
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
We'd like to not install mock in production.  Your package doesn't actually provide any files which import mock so it should not depend on mock for installation