### PR TITLE
Catch decode errors in requests.Response.json()

### DIFF
--- a/sift/client.py
+++ b/sift/client.py
@@ -253,7 +253,12 @@ class Response(object):
 
         if (self.http_status_code not in self.HTTP_CODES_WITHOUT_BODY) \
                 and 'content-length' in http_response.headers:
-            self.body = http_response.json()
+            try:
+                self.body = http_response.json()
+            except ValueError as e:
+                not_json_warning = "Failed to parse json response from {}.  HTTP status code: {}.".format(self.url, self.http_status_code)
+                warnings.warn(not_json_warning)
+                return
             self.api_status = self.body['status']
             self.api_error_message = self.body['error_message']
             if 'request' in self.body.keys() \

--- a/sift/version.py
+++ b/sift/version.py
@@ -1,2 +1,2 @@
-VERSION = '1.1.2.5'
+VERSION = '1.1.2.6'
 API_VERSION = '203'


### PR DESCRIPTION
@fredsadaghiani cc @philfreo

This PR catches the exception outlined in https://github.com/SiftScience/sift-python/issues/37

This exception was recreated by sending requests to an empty experiment api loadbalancer
```
$ python tmp.py
Traceback (most recent call last):
  File "tmp.py", line 5, in <module>
    print sift_client.score("derp")
  File "/Users/johnmcspedon/sift-python/sift/client.py", line 168, in score
    return Response(response)
  File "/Users/johnmcspedon/sift-python/sift/client.py", line 256, in __init__
    self.body = http_response.json()
  File "/Users/johnmcspedon/PE/anaconda/anaconda/lib/python2.7/site-packages/requests/models.py", line 808, in json
    return complexjson.loads(self.text, **kwargs)
  File "/Users/johnmcspedon/PE/anaconda/anaconda/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/Users/johnmcspedon/PE/anaconda/anaconda/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/johnmcspedon/PE/anaconda/anaconda/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

After catching [ValueErrors](http://requests.readthedocs.org/en/master/user/quickstart/#json-response-content), this will log a warning instead of throwing an exception.  [`warnings`](https://docs.python.org/2/library/warnings.html) can be configured to treat these as Exceptions

```
$ python tmp.py
/Users/johnmcspedon/sift-python/sift/client.py:260: UserWarning: Failed to parse json response from http://experiment.api.siftscience.com/v203/score/derp?api_key=omitted.  HTTP status code: 503.
  warnings.warn(not_json_warning)
{ "http_status_code": 503}
```