### PR TITLE
Raise exceptions instead of returning them

### DIFF
--- a/sift/client.py
+++ b/sift/client.py
@@ -30,13 +30,13 @@ class Client(object):
                 to 2 seconds.
         """
         if not isinstance(api_url, str) or len(api_url.strip()) == 0:
-            raise RuntimeError("api_url must be a string")
+            raise ApiException("api_url must be a string")
 
         if api_key is None:
             api_key = sift.api_key
 
         if not isinstance(api_key, str) or len(api_key.strip()) == 0:
-            raise RuntimeError("valid api_key is required")
+            raise ApiException("valid api_key is required")
 
         self.api_key = api_key
         self.url = api_url + '/v%s' % version.API_VERSION
@@ -90,16 +90,15 @@ class Client(object):
 
         Returns:
             A sift.client.Response object if the track call succeeded, otherwise
-            raises a RuntimeError or subclass of
-            requests.exceptions.RequestException.
+            raises an ApiException.
         """
         if not isinstance(
                 event, self.UNICODE_STRING) or len(
                     event.strip()) == 0:
-            raise RuntimeError("event must be a string")
+            raise ApiException("event must be a string")
 
         if not isinstance(properties, dict) or len(properties) == 0:
-            raise RuntimeError("properties dictionary may not be empty")
+            raise ApiException("properties dictionary may not be empty")
 
         headers = {'Content-type': 'application/json',
                    'Accept': '*/*',
@@ -129,7 +128,7 @@ class Client(object):
                 params=params)
             return Response(response)
         except requests.exceptions.RequestException as e:
-            raise e
+            raise ApiException(str(e))
 
     def score(self, user_id, timeout=None):
         """Retrieves a user's fraud score from the Sift Science API.
@@ -141,12 +140,12 @@ class Client(object):
                 event calls.
         Returns:
             A sift.client.Response object if the score call succeeded, or raises
-            a RuntimeError or subclass of requests.exceptions.RequestException.
+            an ApiException.
         """
         if not isinstance(
                 user_id, self.UNICODE_STRING) or len(
                     user_id.strip()) == 0:
-            raise RuntimeError("user_id must be a string")
+            raise ApiException("user_id must be a string")
 
         if timeout is None:
             timeout = self.timeout
@@ -162,7 +161,7 @@ class Client(object):
                 params=params)
             return Response(response)
         except requests.exceptions.RequestException as e:
-            raise e
+            raise ApiException(str(e))
 
     def label(self, user_id, properties, timeout=None):
         """Labels a user as either good or bad through the Sift Science API.
@@ -176,12 +175,12 @@ class Client(object):
             timeout(optional): specify a custom timeout for this call
         Returns:
             A sift.client.Response object if the label call succeeded, otherwise
-            raises a RuntimeError or a subclass of requests.exceptions.RequestException.
+            raises an ApiException.
         """
         if not isinstance(
                 user_id, self.UNICODE_STRING) or len(
                     user_id.strip()) == 0:
-            raise RuntimeError("user_id must be a string")
+            raise ApiException("user_id must be a string")
 
         return self.track(
             '$label',
@@ -200,12 +199,12 @@ class Client(object):
             timeout(optional): specify a custom timeout for this call
         Returns:
             A sift.client.Response object if the unlabel call succeeded, otherwise
-            raises a RuntimeError or subclass of requests.exceptions.RequestException.
+            raises an ApiException.
         """
         if not isinstance(
                 user_id, self.UNICODE_STRING) or len(
                     user_id.strip()) == 0:
-            raise RuntimeError("user_id must be a string")
+            raise ApiException("user_id must be a string")
 
         if timeout is None:
             timeout = self.timeout
@@ -223,7 +222,7 @@ class Client(object):
             return Response(response)
 
         except requests.exceptions.RequestException as e:
-            raise e
+            raise ApiException(str(e))
 
 
 class Response(object):
@@ -272,6 +271,7 @@ class Response(object):
             return 204 == self.http_status_code
 
         return self.api_status == 0
+
 
 class ApiException(Exception):
     def __init__(self, *args, **kwargs):

--- a/sift/client.py
+++ b/sift/client.py
@@ -230,7 +230,10 @@ class Response(object):
     HTTP_CODES_WITHOUT_BODY = [204, 304]
 
     def __init__(self, http_response):
-
+        """
+        Raises ApiException on invalid JSON in Response body or non-2XX HTTP
+        status code.
+        """
         # Set defaults.
         self.body = None
         self.request = None

--- a/sift/client.py
+++ b/sift/client.py
@@ -4,8 +4,6 @@ See: https://siftscience.com/docs/references/events-api
 
 import json
 import requests
-import traceback
-import warnings
 import sys
 if sys.version_info[0] < 3:
     import urllib
@@ -91,7 +89,7 @@ class Client(object):
                  https://siftscience.com/resources/tutorials/formulas
 
         Returns:
-            A requests.Response object if the track call succeeded, otherwise
+            A sift.client.Response object if the track call succeeded, otherwise
             raises a RuntimeError or subclass of
             requests.exceptions.RequestException.
         """
@@ -131,8 +129,6 @@ class Client(object):
                 params=params)
             return Response(response)
         except requests.exceptions.RequestException as e:
-            warnings.warn('Failed to track event: %s' % properties)
-            warnings.warn(traceback.format_exc())
             raise e
 
     def score(self, user_id, timeout=None):
@@ -144,7 +140,7 @@ class Client(object):
             user_id:  A user's id. This id should be the same as the user_id used in
                 event calls.
         Returns:
-            A requests.Response object if the score call succeeded, or raises
+            A sift.client.Response object if the score call succeeded, or raises
             a RuntimeError or subclass of requests.exceptions.RequestException.
         """
         if not isinstance(
@@ -166,8 +162,6 @@ class Client(object):
                 params=params)
             return Response(response)
         except requests.exceptions.RequestException as e:
-            warnings.warn('Failed to get score for user %s' % user_id)
-            warnings.warn(traceback.format_exc())
             raise e
 
     def label(self, user_id, properties, timeout=None):
@@ -181,7 +175,7 @@ class Client(object):
             properties: A dict of additional event-specific attributes to track
             timeout(optional): specify a custom timeout for this call
         Returns:
-            A requests.Response object if the label call succeeded, otherwise
+            A sift.client.Response object if the label call succeeded, otherwise
             raises a RuntimeError or a subclass of requests.exceptions.RequestException.
         """
         if not isinstance(
@@ -205,7 +199,7 @@ class Client(object):
                 event calls.
             timeout(optional): specify a custom timeout for this call
         Returns:
-            A requests.Response object if the unlabel call succeeded, otherwise
+            A sift.client.Response object if the unlabel call succeeded, otherwise
             raises a RuntimeError or subclass of requests.exceptions.RequestException.
         """
         if not isinstance(
@@ -229,8 +223,6 @@ class Client(object):
             return Response(response)
 
         except requests.exceptions.RequestException as e:
-            warnings.warn('Failed to unlabel user %s' % user_id)
-            warnings.warn(traceback.format_exc())
             raise e
 
 
@@ -259,9 +251,9 @@ class Response(object):
                     self.request = json.loads(self.body['request'])
                 else:
                     self.request = None
-            except ValueError as e:
+            except ValueError:
                 not_json_warning = "Failed to parse json response from {}.  HTTP status code: {}.".format(self.url, self.http_status_code)
-                warnings.warn(not_json_warning)
+                raise ApiException(not_json_warning)
             finally:
                 if (int(self.http_status_code) < 200 or int(self.http_status_code) >= 300):
                     non_2xx_warning = "{} returned non-2XX http status code {}".format(self.url, self.http_status_code)

--- a/sift/client.py
+++ b/sift/client.py
@@ -92,8 +92,8 @@ class Client(object):
 
         Returns:
             A requests.Response object if the track call succeeded, otherwise
-            a subclass of requests.exceptions.RequestException indicating the
-            exception that occurred.
+            raises a RuntimeError or subclass of
+            requests.exceptions.RequestException.
         """
         if not isinstance(
                 event, self.UNICODE_STRING) or len(
@@ -133,7 +133,7 @@ class Client(object):
         except requests.exceptions.RequestException as e:
             warnings.warn('Failed to track event: %s' % properties)
             warnings.warn(traceback.format_exc())
-            return e
+            raise e
 
     def score(self, user_id, timeout=None):
         """Retrieves a user's fraud score from the Sift Science API.
@@ -144,9 +144,8 @@ class Client(object):
             user_id:  A user's id. This id should be the same as the user_id used in
                 event calls.
         Returns:
-            A requests.Response object if the score call succeeded, otherwise
-            a subclass of requests.exceptions.RequestException indicating the
-            exception that occurred.
+            A requests.Response object if the score call succeeded, or raises
+            a RuntimeError or subclass of requests.exceptions.RequestException.
         """
         if not isinstance(
                 user_id, self.UNICODE_STRING) or len(
@@ -169,7 +168,7 @@ class Client(object):
         except requests.exceptions.RequestException as e:
             warnings.warn('Failed to get score for user %s' % user_id)
             warnings.warn(traceback.format_exc())
-            return e
+            raise e
 
     def label(self, user_id, properties, timeout=None):
         """Labels a user as either good or bad through the Sift Science API.
@@ -183,8 +182,7 @@ class Client(object):
             timeout(optional): specify a custom timeout for this call
         Returns:
             A requests.Response object if the label call succeeded, otherwise
-            a subclass of requests.exceptions.RequestException indicating the
-            exception that occurred.
+            raises a RuntimeError or a subclass of requests.exceptions.RequestException.
         """
         if not isinstance(
                 user_id, self.UNICODE_STRING) or len(
@@ -208,8 +206,7 @@ class Client(object):
             timeout(optional): specify a custom timeout for this call
         Returns:
             A requests.Response object if the unlabel call succeeded, otherwise
-            a subclass of requests.exceptions.RequestException indicating the
-            exception that occurred.
+            raises a RuntimeError or subclass of requests.exceptions.RequestException.
         """
         if not isinstance(
                 user_id, self.UNICODE_STRING) or len(
@@ -234,7 +231,7 @@ class Client(object):
         except requests.exceptions.RequestException as e:
             warnings.warn('Failed to unlabel user %s' % user_id)
             warnings.warn(traceback.format_exc())
-            return e
+            raise e
 
 
 class Response(object):

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -154,6 +154,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 headers=mock.ANY,
                 timeout=mock.ANY,
                 params={})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_status == 0)
             assert(response.api_error_message == "OK")
@@ -177,6 +178,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 headers=mock.ANY,
                 timeout=test_timeout,
                 params={})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_status == 0)
             assert(response.api_error_message == "OK")
@@ -196,6 +198,7 @@ class TestSiftPythonClient(unittest.TestCase):
                     'api_key': self.test_key},
                 headers=mock.ANY,
                 timeout=mock.ANY)
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_error_message == "OK")
             assert(response.body['score'] == 0.55)
@@ -216,6 +219,7 @@ class TestSiftPythonClient(unittest.TestCase):
                     'api_key': self.test_key},
                 headers=mock.ANY,
                 timeout=test_timeout)
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_error_message == "OK")
             assert(response.body['score'] == 0.55)
@@ -239,6 +243,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 timeout=mock.ANY,
                 params={
                     'return_score': True})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_status == 0)
             assert(response.api_error_message == "OK")
@@ -264,6 +269,7 @@ class TestSiftPythonClient(unittest.TestCase):
             mock_post.assert_called_with(
                 'https://api.siftscience.com/v203/users/%s/labels' %
                 user_id, data=data, headers=mock.ANY, timeout=mock.ANY, params={})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_status == 0)
             assert(response.api_error_message == "OK")
@@ -289,6 +295,7 @@ class TestSiftPythonClient(unittest.TestCase):
             mock_post.assert_called_with(
                 'https://api.siftscience.com/v203/users/%s/labels' %
                 user_id, data=data, headers=mock.ANY, timeout=test_timeout, params={})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_status == 0)
             assert(response.api_error_message == "OK")
@@ -305,6 +312,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 'https://api.siftscience.com/v203/users/%s/labels' %
                 user_id, headers=mock.ANY, timeout=mock.ANY, params={
                     'api_key': self.test_key})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
 
     def test_unicode_string_parameter_support(self):
@@ -345,6 +353,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 'https://api.siftscience.com/v203/users/%s/labels' %
                 urllib.quote(user_id), headers=mock.ANY, timeout=mock.ANY, params={
                     'api_key': self.test_key})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
 
     def test_label_user__with_special_chars_ok(self):
@@ -371,6 +380,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 headers=mock.ANY,
                 timeout=mock.ANY,
                 params={})
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_status == 0)
             assert(response.api_error_message == "OK")
@@ -392,6 +402,7 @@ class TestSiftPythonClient(unittest.TestCase):
                     'api_key': self.test_key},
                 headers=mock.ANY,
                 timeout=mock.ANY)
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_error_message == "OK")
             assert(response.body['score'] == 0.55)
@@ -402,12 +413,15 @@ class TestSiftPythonClient(unittest.TestCase):
             with mock.patch('requests.post') as mock_post:
                 mock_post.side_effect = mock.Mock(
                     side_effect=requests.exceptions.RequestException("Failed"))
-                response = self.sift_client.track(
-                    '$transaction', valid_transaction_properties())
-            assert(len(w) == 2)
-            assert('Failed to track event:' in str(w[0].message))
-            assert('RequestException: Failed' in str(w[1].message))
-            assert('Traceback' in str(w[1].message))
+                try:
+                    response = self.sift_client.track(
+                        '$transaction', valid_transaction_properties())
+                except Exception as e:
+                    assert(isinstance(e, requests.exceptions.RequestException))
+                    assert(len(w) == 2)
+                    assert('Failed to track event:' in str(w[0].message))
+                    assert('RequestException: Failed' in str(w[1].message))
+                    assert('Traceback' in str(w[1].message))
 
     def test_exception_during_score_call(self):
         with warnings.catch_warnings(record=True) as w:
@@ -415,11 +429,14 @@ class TestSiftPythonClient(unittest.TestCase):
             with mock.patch('requests.get') as mock_get:
                 mock_get.side_effect = mock.Mock(
                     side_effect=requests.exceptions.RequestException("Failed"))
-                response = self.sift_client.score('Fred')
-            assert(len(w) == 2)
-            assert('Failed to get score for user Fred' in str(w[0].message))
-            assert('RequestException: Failed' in str(w[1].message))
-            assert('Traceback' in str(w[1].message))
+                try:
+                    response = self.sift_client.score('Fred')
+                except Exception as e:
+                    assert(isinstance(e, requests.exceptions.RequestException))
+                    assert(len(w) == 2)
+                    assert('Failed to get score for user Fred' in str(w[0].message))
+                    assert('RequestException: Failed' in str(w[1].message))
+                    assert('Traceback' in str(w[1].message))
 
     def test_exception_during_unlabel_call(self):
         with warnings.catch_warnings(record=True) as w:
@@ -428,6 +445,8 @@ class TestSiftPythonClient(unittest.TestCase):
                 mock_delete.side_effect = mock.Mock(
                     side_effect=requests.exceptions.RequestException("Failed"))
                 response = self.sift_client.unlabel('Fred')
+                assert(isinstance(response,
+                                  requests.exceptions.RequestException))
 
             assert(len(w) == 2)
             assert('Failed to unlabel user Fred' in str(w[0].message))
@@ -456,6 +475,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 params={
                     'return_action': True})
 
+            assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.api_status == 0)
             assert(response.api_error_message == "OK")

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -444,14 +444,14 @@ class TestSiftPythonClient(unittest.TestCase):
             with mock.patch('requests.delete') as mock_delete:
                 mock_delete.side_effect = mock.Mock(
                     side_effect=requests.exceptions.RequestException("Failed"))
-                response = self.sift_client.unlabel('Fred')
-                assert(isinstance(response,
-                                  requests.exceptions.RequestException))
-
-            assert(len(w) == 2)
-            assert('Failed to unlabel user Fred' in str(w[0].message))
-            assert('RequestException: Failed' in str(w[1].message))
-            assert('Traceback' in str(w[1].message))
+                try:
+                    response = self.sift_client.unlabel('Fred')
+                except Exception as e:
+                    assert(isinstance(e, requests.exceptions.RequestException))
+                    assert(len(w) == 2)
+                    assert('Failed to unlabel user Fred' in str(w[0].message))
+                    assert('RequestException: Failed' in str(w[1].message))
+                    assert('Traceback' in str(w[1].message))
 
     def test_return_actions_on_track(self):
         event = '$transaction'

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -408,50 +408,35 @@ class TestSiftPythonClient(unittest.TestCase):
             assert(response.body['score'] == 0.55)
 
     def test_exception_during_track_call(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            with mock.patch('requests.post') as mock_post:
-                mock_post.side_effect = mock.Mock(
-                    side_effect=requests.exceptions.RequestException("Failed"))
-                try:
-                    response = self.sift_client.track(
-                        '$transaction', valid_transaction_properties())
-                except Exception as e:
-                    assert(isinstance(e, requests.exceptions.RequestException))
-                    assert(len(w) == 2)
-                    assert('Failed to track event:' in str(w[0].message))
-                    assert('RequestException: Failed' in str(w[1].message))
-                    assert('Traceback' in str(w[1].message))
+        warnings.simplefilter("always")
+        with mock.patch('requests.post') as mock_post:
+            mock_post.side_effect = mock.Mock(
+                side_effect=requests.exceptions.RequestException("Failed"))
+            try:
+                response = self.sift_client.track(
+                    '$transaction', valid_transaction_properties())
+            except Exception as e:
+                assert(isinstance(e, requests.exceptions.RequestException))
 
     def test_exception_during_score_call(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            with mock.patch('requests.get') as mock_get:
-                mock_get.side_effect = mock.Mock(
-                    side_effect=requests.exceptions.RequestException("Failed"))
-                try:
-                    response = self.sift_client.score('Fred')
-                except Exception as e:
-                    assert(isinstance(e, requests.exceptions.RequestException))
-                    assert(len(w) == 2)
-                    assert('Failed to get score for user Fred' in str(w[0].message))
-                    assert('RequestException: Failed' in str(w[1].message))
-                    assert('Traceback' in str(w[1].message))
+        warnings.simplefilter("always")
+        with mock.patch('requests.get') as mock_get:
+            mock_get.side_effect = mock.Mock(
+                side_effect=requests.exceptions.RequestException("Failed"))
+            try:
+                response = self.sift_client.score('Fred')
+            except Exception as e:
+                assert(isinstance(e, requests.exceptions.RequestException))
 
     def test_exception_during_unlabel_call(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            with mock.patch('requests.delete') as mock_delete:
-                mock_delete.side_effect = mock.Mock(
-                    side_effect=requests.exceptions.RequestException("Failed"))
-                try:
-                    response = self.sift_client.unlabel('Fred')
-                except Exception as e:
-                    assert(isinstance(e, requests.exceptions.RequestException))
-                    assert(len(w) == 2)
-                    assert('Failed to unlabel user Fred' in str(w[0].message))
-                    assert('RequestException: Failed' in str(w[1].message))
-                    assert('Traceback' in str(w[1].message))
+        warnings.simplefilter("always")
+        with mock.patch('requests.delete') as mock_delete:
+            mock_delete.side_effect = mock.Mock(
+                side_effect=requests.exceptions.RequestException("Failed"))
+            try:
+                response = self.sift_client.unlabel('Fred')
+            except Exception as e:
+                assert(isinstance(e, requests.exceptions.RequestException))
 
     def test_return_actions_on_track(self):
         event = '$transaction'

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -93,7 +93,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_global_api_key(self):
         # test for error if global key is undefined
-        self.assertRaises(RuntimeError, sift.Client)
+        self.assertRaises(sift.client.ApiException, sift.Client)
         sift.api_key = "a_test_global_api_key"
         local_api_key = "a_test_local_api_key"
 
@@ -110,32 +110,32 @@ class TestSiftPythonClient(unittest.TestCase):
         assert(client2.api_key == sift.api_key)
 
     def test_constructor_requires_valid_api_key(self):
-        self.assertRaises(RuntimeError, sift.Client, None)
-        self.assertRaises(RuntimeError, sift.Client, '')
+        self.assertRaises(sift.client.ApiException, sift.Client, None)
+        self.assertRaises(sift.client.ApiException, sift.Client, '')
 
     def test_constructor_invalid_api_url(self):
-        self.assertRaises(RuntimeError, sift.Client, self.test_key, None)
-        self.assertRaises(RuntimeError, sift.Client, self.test_key, '')
+        self.assertRaises(sift.client.ApiException, sift.Client, self.test_key, None)
+        self.assertRaises(sift.client.ApiException, sift.Client, self.test_key, '')
 
     def test_constructor_api_key(self):
         client = sift.Client(self.test_key)
         self.assertEqual(client.api_key, self.test_key)
 
     def test_track_requires_valid_event(self):
-        self.assertRaises(RuntimeError, self.sift_client.track, None, {})
-        self.assertRaises(RuntimeError, self.sift_client.track, '', {})
-        self.assertRaises(RuntimeError, self.sift_client.track, 42, {})
+        self.assertRaises(sift.client.ApiException, self.sift_client.track, None, {})
+        self.assertRaises(sift.client.ApiException, self.sift_client.track, '', {})
+        self.assertRaises(sift.client.ApiException, self.sift_client.track, 42, {})
 
     def test_track_requires_properties(self):
         event = 'custom_event'
-        self.assertRaises(RuntimeError, self.sift_client.track, event, None)
-        self.assertRaises(RuntimeError, self.sift_client.track, event, 42)
-        self.assertRaises(RuntimeError, self.sift_client.track, event, {})
+        self.assertRaises(sift.client.ApiException, self.sift_client.track, event, None)
+        self.assertRaises(sift.client.ApiException, self.sift_client.track, event, 42)
+        self.assertRaises(sift.client.ApiException, self.sift_client.track, event, {})
 
     def test_score_requires_user_id(self):
-        self.assertRaises(RuntimeError, self.sift_client.score, None)
-        self.assertRaises(RuntimeError, self.sift_client.score, '')
-        self.assertRaises(RuntimeError, self.sift_client.score, 42)
+        self.assertRaises(sift.client.ApiException, self.sift_client.score, None)
+        self.assertRaises(sift.client.ApiException, self.sift_client.score, '')
+        self.assertRaises(sift.client.ApiException, self.sift_client.score, 42)
 
     def test_event_ok(self):
         event = '$transaction'
@@ -416,7 +416,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 response = self.sift_client.track(
                     '$transaction', valid_transaction_properties())
             except Exception as e:
-                assert(isinstance(e, requests.exceptions.RequestException))
+                assert(isinstance(e, sift.client.ApiException))
 
     def test_exception_during_score_call(self):
         warnings.simplefilter("always")
@@ -426,7 +426,7 @@ class TestSiftPythonClient(unittest.TestCase):
             try:
                 response = self.sift_client.score('Fred')
             except Exception as e:
-                assert(isinstance(e, requests.exceptions.RequestException))
+                assert(isinstance(e, sift.client.ApiException))
 
     def test_exception_during_unlabel_call(self):
         warnings.simplefilter("always")
@@ -436,7 +436,7 @@ class TestSiftPythonClient(unittest.TestCase):
             try:
                 response = self.sift_client.unlabel('Fred')
             except Exception as e:
-                assert(isinstance(e, requests.exceptions.RequestException))
+                assert(isinstance(e, sift.client.ApiException))
 
     def test_return_actions_on_track(self):
         event = '$transaction'


### PR DESCRIPTION
This pull request is to change the error behaviour for track(), score(), label() and unlabel() methods to  be more pythonic in raising exceptions instead of returning them.

Currently it is necessary to call a method and check the response type as we don't know if we'll get a Response object come back or a subclass of Exception, eg. from the docs (https://siftscience.com/developers/docs/python/automation-apis/score-api):

```python
response = client.score("USER_ID_HERE")
response.is_ok()            # false on failed score requests.
```

But if score() returns an exception then the is_ok() method on the second line doesn't exist and an AttributeError exception is raised.

A more complete way to error check would be this awkward mixture of try/except and if:
```python
try:
    response = sift_client.score('me')
    if isinstance(response, Response):
        if response.is_ok():
            # yeah! success
        else:
            # method failed, but without exception
    elif isinstance(response, RequestException):
        # oh, no... this is a RequestException
except RuntimeError:
    # oh, no... this is a RuntimeError
```

but with the pull request we can just do it idiomatically:

```python
try:
    response = sift_client.score('me')
    if response.is_ok():
        print 'it is ok to call is_ok() now'
except RuntimeError as e:
    # invalid args
except RequestException as e:
    # request failed
```