### PR TITLE
(For Nick) Add Decisions API (get, post /decisions) to python client

### DIFF
--- a/sift/client.py
+++ b/sift/client.py
@@ -343,10 +343,9 @@ class Client(object):
             params['abuse_types'] = abuse_types
 
         try:
-            get = requests.get(self._get_decisions_url(self.account_id), params=params,
-                               auth=requests.auth.HTTPBasicAuth(self.api_key, ''),
-                               headers={'User-Agent': self._user_agent()}, timeout=timeout)
-            return Response(get)
+            return Response(requests.get(self._get_decisions_url(self.account_id), params=params,
+                                         auth=requests.auth.HTTPBasicAuth(self.api_key, ''),
+                                         headers={'User-Agent': self._user_agent()}, timeout=timeout))
 
         except requests.exceptions.RequestException as e:
             raise ApiException(str(e))

--- a/sift/client.py
+++ b/sift/client.py
@@ -319,9 +319,9 @@ class Client(object):
 
         Args:
             entity_type: only return decisions applicable to entity type {USER|ORDER}
-            limit: number of query results (decisions) to return [default: 100]
-            start_from: result set offset for use in pagination [default: 0]
-            abuse_types: csv of abuse_types by which to filter returned decisions (optional)
+            limit: number of query results (decisions) to return [optional, default: 100]
+            start_from: result set offset for use in pagination [optional, default: 0]
+            abuse_types: comma-separated list of abuse_types used to filter returned decisions (optional)
 
         Returns:
             A sift.client.Response object containing array of decisions if call succeeded
@@ -364,7 +364,7 @@ class Client(object):
             properties:
                 decision_id: decision to apply to user
                 source: {one of MANUAL_REVIEW | AUTOMATED_RULE | CHARGEBACK}
-                analyst: id or email, required if `source: MANUAL_REVIEW`
+                analyst: id or email, required if 'source: MANUAL_REVIEW'
                 time: in millis when decision was applied
         Returns
             A sift.client.Response object if the call succeeded, else raises an ApiException

--- a/sift/client.py
+++ b/sift/client.py
@@ -334,7 +334,7 @@ class Client(object):
         params = {}
 
         if not isinstance(entity_type, self.UNICODE_STRING) or len(entity_type.strip()) == 0 \
-                or entity_type not in {'user', 'order'}:
+                or entity_type.lower() not in ['user', 'order']:
             raise ApiException("entity_type must be one of {user, order}")
 
         params['entity_type'] = entity_type

--- a/sift/client.py
+++ b/sift/client.py
@@ -369,6 +369,7 @@ class Client(object):
                 decision_id: decision to apply to user
                 source: {one of MANUAL_REVIEW | AUTOMATED_RULE | CHARGEBACK}
                 analyst: id or email, required if `source: MANUAL_REVIEW`
+                description: note or description of decision applied or reasons (optional)
                 time: in millis when decision was applied
         Returns
             A sift.client.Response object if the call succeeded, else raises an ApiException

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -296,7 +296,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_get_decisions(self):
         mock_response = mock.Mock()
-        getDecisionsResponseJson =  \
+        get_decisions_response_json =  \
             '{' \
                 '"data": [' \
                     '{' \
@@ -317,7 +317,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 '"next_ref": "v3/accounts/accountId/decisions"' \
             '}'
 
-        mock_response.content = getDecisionsResponseJson
+        mock_response.content = get_decisions_response_json
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
@@ -350,7 +350,7 @@ class TestSiftPythonClient(unittest.TestCase):
                 'description': 'called user and verified account',
                 'time': 1481569575
              }
-        applyDecisionResponseJson = '{' \
+        apply_decision_response_json = '{' \
                                     '"entity": {' \
                                         '"id": "54321",' \
                                         '"type": "user"'    \
@@ -359,7 +359,7 @@ class TestSiftPythonClient(unittest.TestCase):
                                         '"id":"user_looks_ok_legacy"' \
                                     '},' \
                                     '"time":"1481569575"}'
-        mock_response.content = applyDecisionResponseJson
+        mock_response.content = apply_decision_response_json
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
@@ -376,10 +376,58 @@ class TestSiftPythonClient(unittest.TestCase):
             assert(response.http_status_code == 200)
             assert(response.is_ok())
 
+    def test_validate_no_user_id_string_fails(self):
+        apply_decision_request = {
+                'decision_id': 'user_looks_ok_legacy',
+                'source': 'MANUAL_REVIEW',
+                'analyst': 'analyst@biz.com',
+                'description': 'called user and verified account',
+             }
+        try:
+            self.sift_client._validate_apply_decision_request(apply_decision_request, 123)
+        except Exception as e:
+            assert(isinstance(e, sift.client.ApiException))
+
+    def test_apply_decision_to_order(self):
+        try:
+            self.sift_client.apply_order_decision("user_id", None, {})
+        except Exception as e:
+            assert(isinstance(e, sift.client.ApiException))
+
+    def test_validate_apply_decision_request_no_analyst_fails(self):
+        apply_decision_request = {
+            'decision_id': 'user_looks_ok_legacy',
+            'source': 'MANUAL_REVIEW',
+            'time': 1481569575
+        }
+
+        try:
+            self.sift_client._validate_apply_decision_request(apply_decision_request, "userId")
+        except Exception as e:
+            assert(isinstance(e, sift.client.ApiException))
+
+    def test_validate_apply_decision_request_no_source_fails(self):
+        apply_decision_request = {
+            'decision_id': 'user_looks_ok_legacy',
+            'time': 1481569575
+        }
+
+        try:
+            self.sift_client._validate_apply_decision_request(apply_decision_request, "userId")
+        except Exception as e:
+            assert(isinstance(e, sift.client.ApiException))
+
+    def test_validate_empty_apply_decision_request_fails(self):
+        apply_decision_request = {}
+        try:
+            self.sift_client._validate_apply_decision_request(apply_decision_request, "userId")
+        except Exception as e:
+            assert(isinstance(e, sift.client.ApiException))
+
     def test_apply_decision_manual_review_no_analyst_fails(self):
         user_id = '54321'
         mock_response = mock.Mock()
-        applyDecisionRequest = {
+        apply_decision_request = {
             'decision_id': 'user_looks_ok_legacy',
             'source': 'MANUAL_REVIEW',
             'time': 1481569575
@@ -387,8 +435,8 @@ class TestSiftPythonClient(unittest.TestCase):
         with mock.patch('requests.post') as mock_post:
             mock_post.return_value = mock_response
         try:
-            response = self.sift_client.apply_user_decision(user_id, applyDecisionRequest)
-            data = json.dumps(applyDecisionRequest)
+            response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
+            data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
                 auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
@@ -398,15 +446,15 @@ class TestSiftPythonClient(unittest.TestCase):
     def test_apply_decision_no_source_fails(self):
         user_id = '54321'
         mock_response = mock.Mock()
-        applyDecisionRequest = {
+        apply_decision_request = {
             'decision_id': 'user_looks_ok_legacy',
             'time': 1481569575
         }
         with mock.patch('requests.post') as mock_post:
             mock_post.return_value = mock_response
         try:
-            response = self.sift_client.apply_user_decision(user_id, applyDecisionRequest)
-            data = json.dumps(applyDecisionRequest)
+            response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
+            data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
                 auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
@@ -416,7 +464,7 @@ class TestSiftPythonClient(unittest.TestCase):
     def test_apply_decision_invalid_source_fails(self):
         user_id = '54321'
         mock_response = mock.Mock()
-        applyDecisionRequest = {
+        apply_decision_request = {
             'decision_id': 'user_looks_ok_legacy',
             'source': 'INVALID_SOURCE',
             'time': 1481569575
@@ -424,8 +472,8 @@ class TestSiftPythonClient(unittest.TestCase):
         with mock.patch('requests.post') as mock_post:
             mock_post.return_value = mock_response
         try:
-            response = self.sift_client.apply_user_decision(user_id, applyDecisionRequest)
-            data = json.dumps(applyDecisionRequest)
+            response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
+            data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
                 auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
@@ -436,13 +484,13 @@ class TestSiftPythonClient(unittest.TestCase):
         user_id = '54321'
         order_id = '43210'
         mock_response = mock.Mock()
-        applyDecisionRequest = {
+        apply_decision_request = {
                 'decision_id': 'order_looks_bad_payment_abuse',
                 'source': 'AUTOMATED_RULE',
                 'time': 1481569575
             }
 
-        applyDecisionResponseJson = '{' \
+        apply_decision_response_json = '{' \
                                     '"entity": {' \
                                         '"id": "54321",' \
                                         '"type": "order"'    \
@@ -452,14 +500,14 @@ class TestSiftPythonClient(unittest.TestCase):
                                     '},' \
                                     '"time":"1481569575"}'
 
-        mock_response.content = applyDecisionResponseJson
+        mock_response.content = apply_decision_response_json
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
         with mock.patch('requests.post') as mock_post:
             mock_post.return_value = mock_response
-            response = self.sift_client.apply_order_decision(user_id, order_id, applyDecisionRequest)
-            data = json.dumps(applyDecisionRequest)
+            response = self.sift_client.apply_order_decision(user_id, order_id, apply_decision_request)
+            data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/orders/%s/decisions' % (user_id,order_id),
                 auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -301,18 +301,18 @@ class TestSiftPythonClient(unittest.TestCase):
                 'decision_id': 'user_looks_ok_legacy',
                 'source': 'MANUAL_REVIEW',
                 'analyst': 'analyst@biz.com',
+                'description': 'called user and verified account',
                 'time': 1481569575
              }
         applyDecisionResponseJson = '{' \
-                                    '"time":"1481569575",' \
-                                    '"status":0,' \
-                                    '"request": {' \
-                                        '"decision_id":"user_looks_ok_legacy",' \
-                                        '"source":"MANUAL_REVIEW",' \
-                                        '"analyst":"analyst@biz.com",' \
-                                        '"time":"1481569575"' \
+                                    '"entity": {' \
+                                        '"id": "54321",' \
+                                        '"type": "user"'    \
                                     '},' \
-                                    '"error_message":"OK"}'
+                                    '"decision": {' \
+                                        '"id":"user_looks_ok_legacy"' \
+                                    '},' \
+                                    '"time":"1481569575"}'
         mock_response.content = applyDecisionResponseJson
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
@@ -324,10 +324,11 @@ class TestSiftPythonClient(unittest.TestCase):
             mock_post.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
                 auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+
             assert(isinstance(response, sift.client.Response))
+            assert(response.body['entity']['type'] == 'user')
+            assert(response.http_status_code == 200)
             assert(response.is_ok())
-            assert(response.api_status == 0)
-            assert(response.api_error_message == "OK")
 
     def test_apply_decision_manual_review_no_analyst_fails(self):
         user_id = '54321'
@@ -395,15 +396,15 @@ class TestSiftPythonClient(unittest.TestCase):
                 'time': 1481569575
             }
 
-        applyDecisionResponseJson = '{'\
-            '"time": "1481569575",' \
-            '"status": 0,' \
-            '"request": {' \
-                '"decision_id":"order_looks_bad_payment_abuse",' \
-                '"source":"AUTOMATED_RULE",' \
-                '"time":"1481569575"' \
-            '},' \
-            '"error_message": "OK"}'
+        applyDecisionResponseJson = '{' \
+                                    '"entity": {' \
+                                        '"id": "54321",' \
+                                        '"type": "order"'    \
+                                    '},' \
+                                    '"decision": {' \
+                                        '"id":"order_looks_bad_payment_abuse"' \
+                                    '},' \
+                                    '"time":"1481569575"}'
 
         mock_response.content = applyDecisionResponseJson
         mock_response.json.return_value = json.loads(mock_response.content)
@@ -418,8 +419,8 @@ class TestSiftPythonClient(unittest.TestCase):
                 auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
-            assert(response.api_status == 0)
-            assert(response.api_error_message == "OK")
+            assert(response.http_status_code == 200)
+            assert(response.body['entity']['type'] == 'order')
 
     def test_label_user_ok(self):
         user_id = '54321'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -294,6 +294,12 @@ class TestSiftPythonClient(unittest.TestCase):
             assert(response.body['score_response']['scores']['content_abuse']['score'] == 0.14)
             assert(response.body['score_response']['scores']['payment_abuse']['score'] == 0.97)
 
+    def test_get_decisions_fails(self):
+        try:
+            self.sift_client.get_decisions('usr')
+        except Exception as e:
+            assert(isinstance(e, sift.client.ApiException))
+
     def test_get_decisions(self):
         mock_response = mock.Mock()
         get_decisions_response_json =  \

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -343,7 +343,7 @@ class TestSiftPythonClient(unittest.TestCase):
     def test_apply_decision_to_user_ok(self):
         user_id = '54321'
         mock_response = mock.Mock()
-        applyDecisionRequest = {
+        apply_decision_request = {
                 'decision_id': 'user_looks_ok_legacy',
                 'source': 'MANUAL_REVIEW',
                 'analyst': 'analyst@biz.com',
@@ -365,8 +365,8 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.headers = response_with_data_header()
         with mock.patch('requests.post') as mock_post:
             mock_post.return_value = mock_response
-            response = self.sift_client.apply_user_decision(user_id, applyDecisionRequest)
-            data = json.dumps(applyDecisionRequest)
+            response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
+            data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
                 auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)


### PR DESCRIPTION
This PR will update the sift pythong client to reflect the public apply decisions API `POST /decisions` endpoint. 
* Related paper doc for proposed public API: https://paper.dropbox.com/doc/Decisions-Public-API-Proposal-VGu3r2SDVavhnpNSmT2km

Changes:
* Add ApplyDecisionsRequest/Response test
* Add GetDecisionsRequest/Response test
* Add to SiftClient
cc @lopatin 