### PR TITLE
(For David) Add support for rescore_user and get_user_score

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+4.3.0.0 2018-07-31
+==================
+-   Add support for rescore_user and get_user_score APIs
+
 4.2.0.0 2018-07-05
 ==================
 -   Add new query parameter force_workflow_run

--- a/sift/client.py
+++ b/sift/client.py
@@ -213,6 +213,91 @@ class Client(object):
             raise ApiException(str(e))
 
 
+    def get_user_score(self, user_id, timeout=None, abuse_types=None):
+        """Fetches the latest score(s) computed for the specified user and abuse types from the Sift Science API.
+        As opposed to client.score() and client.rescore_user(), this *does not* compute a new score for the user; it
+        simply fetches the latest score(s) which have computed. These scores may be arbitrarily old.
+
+        This call is blocking. See https://siftscience.com/developers/docs/python/score-api/get-score for more details.
+
+        Args:
+            user_id:  A user's id. This id should be the same as the user_id used in
+                event calls.
+
+            timeout(optional): Use a custom timeout (in seconds) for this call.
+
+            abuse_types(optional): List of abuse types, specifying for which abuse types a score
+                 should be returned (if scores were requested).  If not specified, a score will
+                 be returned for every abuse_type to which you are subscribed.
+
+            version(optional): Use a different version of the Sift Science API for this call.
+
+        Returns:
+            A sift.client.Response object if the score call succeeded, or raises
+            an ApiException.
+        """
+        if not isinstance(user_id, self.UNICODE_STRING) or len(user_id.strip()) == 0:
+            raise ApiException("user_id must be a string")
+
+        if timeout is None:
+            timeout = self.timeout
+
+        headers = {'User-Agent': self._user_agent()}
+        params = {'api_key': self.api_key}
+        if abuse_types:
+            params['abuse_types'] = ','.join(abuse_types)
+
+        try:
+            response = requests.get(
+                self._user_score_url(user_id, self.version),
+                headers=headers,
+                timeout=timeout,
+                params=params)
+            return Response(response)
+        except requests.exceptions.RequestException as e:
+            raise ApiException(str(e))
+
+
+    def rescore_user(self, user_id, timeout=None, abuse_types=None):
+        """Rescores the specified user for the specified abuse types and returns the resulting score(s).
+        This call is blocking. See https://siftscience.com/developers/docs/python/score-api/rescore for more details.
+
+        Args:
+            user_id:  A user's id. This id should be the same as the user_id used in
+                event calls.
+
+            timeout(optional): Use a custom timeout (in seconds) for this call.
+
+            abuse_types(optional): List of abuse types, specifying for which abuse types a score
+                 should be returned (if scores were requested).  If not specified, a score will
+                 be returned for every abuse_type to which you are subscribed.
+
+        Returns:
+            A sift.client.Response object if the score call succeeded, or raises
+            an ApiException.
+        """
+        if not isinstance(user_id, self.UNICODE_STRING) or len(user_id.strip()) == 0:
+            raise ApiException("user_id must be a string")
+
+        if timeout is None:
+            timeout = self.timeout
+
+        headers = {'User-Agent': self._user_agent()}
+        params = {'api_key': self.api_key}
+        if abuse_types:
+            params['abuse_types'] = ','.join(abuse_types)
+
+        try:
+            response = requests.post(
+                self._user_score_url(user_id, self.version),
+                headers=headers,
+                timeout=timeout,
+                params=params)
+            return Response(response)
+        except requests.exceptions.RequestException as e:
+            raise ApiException(str(e))
+
+
     def label(self, user_id, properties, timeout=None, version=None):
         """Labels a user as either good or bad through the Sift Science API.
         This call is blocking.  Check out https://siftscience.com/resources/references/labels_api.html
@@ -657,6 +742,9 @@ class Client(object):
 
     def _score_url(self, user_id, version):
         return self.url + '/v%s/score/%s' % (version, urllib.quote(user_id))
+
+    def _user_score_url(self, user_id, version):
+        return self.url + '/v%s/users/%s/score' % (version, urllib.quote(user_id))
 
     def _label_url(self, user_id, version):
         return self.url + '/v%s/users/%s/labels' % (version, urllib.quote(user_id))

--- a/sift/client.py
+++ b/sift/client.py
@@ -230,8 +230,6 @@ class Client(object):
                  should be returned (if scores were requested).  If not specified, a score will
                  be returned for every abuse_type to which you are subscribed.
 
-            version(optional): Use a different version of the Sift Science API for this call.
-
         Returns:
             A sift.client.Response object if the score call succeeded, or raises
             an ApiException.

--- a/sift/version.py
+++ b/sift/version.py
@@ -1,2 +1,2 @@
-VERSION = '4.1.0'
+VERSION = '4.3.0'
 API_VERSION = '205'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -327,6 +327,34 @@ class TestSiftPythonClient(unittest.TestCase):
             assert('latest_decisions' in response.body)
 
 
+    def test_get_user_score_with_abuse_types_ok(self):
+        """Test the GET /{version}/users/{userId}/score?abuse_types=... API, i.e. client.get_user_score()
+        """
+        test_timeout = 5
+        mock_response = mock.Mock()
+        mock_response.content = USER_SCORE_RESPONSE_JSON
+        mock_response.json.return_value = json.loads(mock_response.content)
+        mock_response.status_code = 200
+        mock_response.headers = response_with_data_header()
+        with mock.patch('requests.get') as mock_get:
+            mock_get.return_value = mock_response
+            response = self.sift_client.get_user_score('12345',
+                                                       abuse_types=['payment_abuse', 'content_abuse'],
+                                                       timeout=test_timeout)
+            mock_get.assert_called_with(
+                'https://api.siftscience.com/v205/users/12345/score',
+                params={'api_key': self.test_key, 'abuse_types': 'payment_abuse,content_abuse'},
+                headers=mock.ANY,
+                timeout=test_timeout)
+            assert(isinstance(response, sift.client.Response))
+            assert(response.is_ok())
+            assert(response.api_error_message == "OK")
+            assert(response.body['entity_id'] == '12345')
+            assert(response.body['scores']['content_abuse']['score'] == 0.14)
+            assert(response.body['scores']['payment_abuse']['score'] == 0.97)
+            assert('latest_decisions' in response.body)
+
+
     def test_rescore_user_ok(self):
         """Test the POST /{version}/users/{userId}/score API, i.e. client.rescore_user()
         """
@@ -342,6 +370,34 @@ class TestSiftPythonClient(unittest.TestCase):
             mock_post.assert_called_with(
                 'https://api.siftscience.com/v205/users/12345/score',
                 params={'api_key': self.test_key},
+                headers=mock.ANY,
+                timeout=test_timeout)
+            assert(isinstance(response, sift.client.Response))
+            assert(response.is_ok())
+            assert(response.api_error_message == "OK")
+            assert(response.body['entity_id'] == '12345')
+            assert(response.body['scores']['content_abuse']['score'] == 0.14)
+            assert(response.body['scores']['payment_abuse']['score'] == 0.97)
+            assert('latest_decisions' in response.body)
+
+
+    def test_rescore_user_with_abuse_types_ok(self):
+        """Test the POST /{version}/users/{userId}/score?abuse_types=... API, i.e. client.rescore_user()
+        """
+        test_timeout = 5
+        mock_response = mock.Mock()
+        mock_response.content = USER_SCORE_RESPONSE_JSON
+        mock_response.json.return_value = json.loads(mock_response.content)
+        mock_response.status_code = 200
+        mock_response.headers = response_with_data_header()
+        with mock.patch('requests.post') as mock_post:
+            mock_post.return_value = mock_response
+            response = self.sift_client.rescore_user('12345',
+                                                     abuse_types=['payment_abuse', 'content_abuse'],
+                                                     timeout=test_timeout)
+            mock_post.assert_called_with(
+                'https://api.siftscience.com/v205/users/12345/score',
+                params={'api_key': self.test_key, 'abuse_types': 'payment_abuse,content_abuse'},
                 headers=mock.ANY,
                 timeout=test_timeout)
             assert(isinstance(response, sift.client.Response))


### PR DESCRIPTION
@garylee1 

**Purpose**
Adds support for the new GET|Post /v205/users/{userId}/score APIs to this client library.

**Testing Plan**
1. Added new unit tests
2. Tested manually on the Sift test account.