### PR TITLE
Enable connection pooling fixes #64

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -221,7 +221,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.track(event, valid_transaction_properties())
             mock_post.assert_called_with(
@@ -243,7 +243,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.track(
                 event, valid_transaction_properties(), timeout=test_timeout)
@@ -264,10 +264,10 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_post:
-            mock_post.return_value = mock_response
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
+            mock_get.return_value = mock_response
             response = self.sift_client.score('12345')
-            mock_post.assert_called_with(
+            mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/score/12345',
                 params={'api_key': self.test_key},
                 headers=mock.ANY,
@@ -286,10 +286,10 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_post:
-            mock_post.return_value = mock_response
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
+            mock_get.return_value = mock_response
             response = self.sift_client.score('12345', test_timeout)
-            mock_post.assert_called_with(
+            mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/score/12345',
                 params={'api_key': self.test_key},
                 headers=mock.ANY,
@@ -310,7 +310,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
             response = self.sift_client.get_user_score('12345', test_timeout)
             mock_get.assert_called_with(
@@ -336,7 +336,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
             response = self.sift_client.get_user_score('12345',
                                                        abuse_types=['payment_abuse', 'content_abuse'],
@@ -364,7 +364,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.rescore_user('12345', test_timeout)
             mock_post.assert_called_with(
@@ -390,7 +390,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.rescore_user('12345',
                                                      abuse_types=['payment_abuse', 'content_abuse'],
@@ -417,7 +417,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.track(
                 event,
@@ -471,7 +471,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
 
             response = self.sift_client.get_decisions(entity_type="user",
@@ -482,7 +482,6 @@ class TestSiftPythonClient(unittest.TestCase):
             mock_get.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/decisions',
                 headers=mock.ANY,
-                auth=mock.ANY,
                 params={'entity_type':'user','limit':10,'abuse_types':'legacy,payment_abuse'},
                 timeout=3)
 
@@ -517,7 +516,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
 
             response = self.sift_client.get_decisions(entity_type="session",
@@ -528,7 +527,6 @@ class TestSiftPythonClient(unittest.TestCase):
             mock_get.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/decisions',
                 headers=mock.ANY,
-                auth=mock.ANY,
                 params={'entity_type':'session','limit':10,'abuse_types':'account_takeover'},
                 timeout=3)
 
@@ -559,13 +557,12 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
             data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
-                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
-                auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id, data=data, headers=mock.ANY, timeout=mock.ANY)
 
             assert(isinstance(response, sift.client.Response))
             assert(response.body['entity']['type'] == 'user')
@@ -646,14 +643,13 @@ class TestSiftPythonClient(unittest.TestCase):
             'source': 'MANUAL_REVIEW',
             'time': 1481569575
         }
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
         try:
             response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
             data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
-                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
-                auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id, data=data, headers=mock.ANY, timeout=mock.ANY)
         except Exception as e:
             assert(isinstance(e, sift.client.ApiException))
 
@@ -664,14 +660,13 @@ class TestSiftPythonClient(unittest.TestCase):
             'decision_id': 'user_looks_ok_legacy',
             'time': 1481569575
         }
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
         try:
             response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
             data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
-                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
-                auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id, data=data, headers=mock.ANY, timeout=mock.ANY)
         except Exception as e:
             assert(isinstance(e, sift.client.ApiException))
 
@@ -683,14 +678,13 @@ class TestSiftPythonClient(unittest.TestCase):
             'source': 'INVALID_SOURCE',
             'time': 1481569575
         }
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
         try:
             response = self.sift_client.apply_user_decision(user_id, apply_decision_request)
             data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
-                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id,
-                auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/decisions' % user_id, data=data, headers=mock.ANY, timeout=mock.ANY)
         except Exception as e:
             assert(isinstance(e, sift.client.ApiException))
 
@@ -718,13 +712,12 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.apply_order_decision(user_id, order_id, apply_decision_request)
             data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
-                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/orders/%s/decisions' % (user_id,order_id),
-                auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/orders/%s/decisions' % (user_id,order_id), data=data, headers=mock.ANY, timeout=mock.ANY)
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.http_status_code == 200)
@@ -754,13 +747,12 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.apply_session_decision(user_id, session_id, apply_decision_request)
             data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
-                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/sessions/%s/decisions' % (user_id,session_id),
-                auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/sessions/%s/decisions' % (user_id,session_id), data=data, headers=mock.ANY, timeout=mock.ANY)
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.http_status_code == 200)
@@ -790,13 +782,12 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.apply_content_decision(user_id, content_id, apply_decision_request)
             data = json.dumps(apply_decision_request)
             mock_post.assert_called_with(
-                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/content/%s/decisions' % (user_id,content_id),
-                auth=mock.ANY, data=data, headers=mock.ANY, timeout=mock.ANY)
+                'https://api3.siftscience.com/v3/accounts/ACCT/users/%s/content/%s/decisions' % (user_id,content_id), data=data, headers=mock.ANY, timeout=mock.ANY)
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.http_status_code == 200)
@@ -809,7 +800,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.label(user_id, valid_label_properties())
             properties = {
@@ -837,7 +828,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.label(
                 user_id, valid_label_properties(), test_timeout)
@@ -862,7 +853,7 @@ class TestSiftPythonClient(unittest.TestCase):
         user_id = '54321'
         mock_response = mock.Mock()
         mock_response.status_code = 204
-        with mock.patch('requests.delete') as mock_delete:
+        with mock.patch.object(self.sift_client.session, 'delete') as mock_delete:
             mock_delete.return_value = mock_response
             response = self.sift_client.unlabel(user_id, abuse_type='account_abuse')
             mock_delete.assert_called_with(
@@ -885,7 +876,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
             user_id = u'23056'
 
-            with mock.patch('requests.post') as mock_post:
+            with mock.patch.object(self.sift_client.session, 'post') as mock_post:
                 mock_post.return_value = mock_response
                 assert(self.sift_client.track(
                     u'$transaction',
@@ -893,8 +884,8 @@ class TestSiftPythonClient(unittest.TestCase):
                 assert(self.sift_client.label(
                     user_id,
                     valid_label_properties()))
-            with mock.patch('requests.get') as mock_post:
-                mock_post.return_value = mock_response
+            with mock.patch.object(self.sift_client.session, 'get') as mock_get:
+                mock_get.return_value = mock_response
                 assert(self.sift_client.score(
                     user_id, abuse_types=[u'payment_abuse', 'content_abuse']))
 
@@ -902,7 +893,7 @@ class TestSiftPythonClient(unittest.TestCase):
         user_id = "54321=.-_+@:&^%!$"
         mock_response = mock.Mock()
         mock_response.status_code = 204
-        with mock.patch('requests.delete') as mock_delete:
+        with mock.patch.object(self.sift_client.session, 'delete') as mock_delete:
             mock_delete.return_value = mock_response
             response = self.sift_client.unlabel(user_id)
             mock_delete.assert_called_with(
@@ -920,7 +911,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.label(
                 user_id, valid_label_properties())
@@ -951,10 +942,10 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_post:
-            mock_post.return_value = mock_response
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
+            mock_get.return_value = mock_response
             response = self.sift_client.score(user_id, abuse_types=['legacy'])
-            mock_post.assert_called_with(
+            mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/score/%s' % urllib.quote(user_id),
                 params={'api_key': self.test_key, 'abuse_types': 'legacy'},
                 headers=mock.ANY,
@@ -968,7 +959,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_exception_during_track_call(self):
         warnings.simplefilter("always")
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.side_effect = mock.Mock(
                 side_effect=requests.exceptions.RequestException("Failed"))
             try:
@@ -979,7 +970,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_exception_during_score_call(self):
         warnings.simplefilter("always")
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.side_effect = mock.Mock(
                 side_effect=requests.exceptions.RequestException("Failed"))
             try:
@@ -989,7 +980,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_exception_during_unlabel_call(self):
         warnings.simplefilter("always")
-        with mock.patch('requests.delete') as mock_delete:
+        with mock.patch.object(self.sift_client.session, 'delete') as mock_delete:
             mock_delete.side_effect = mock.Mock(
                 side_effect=requests.exceptions.RequestException("Failed"))
             try:
@@ -1006,7 +997,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
 
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
 
             response = self.sift_client.track(
@@ -1036,13 +1027,13 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
 
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
 
             response = self.sift_client.get_workflow_status('4zxwibludiaaa', timeout=3)
             mock_get.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/workflows/runs/4zxwibludiaaa',
-                headers=mock.ANY, auth=mock.ANY, timeout=3)
+                headers=mock.ANY, timeout=3)
 
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
@@ -1055,13 +1046,13 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
 
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
 
             response = self.sift_client.get_user_decisions('example_user')
             mock_get.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/example_user/decisions',
-                headers=mock.ANY, auth=mock.ANY, timeout=mock.ANY)
+                headers=mock.ANY, timeout=mock.ANY)
 
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
@@ -1074,13 +1065,13 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
 
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
 
             response = self.sift_client.get_order_decisions('example_order')
             mock_get.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/orders/example_order/decisions',
-                headers=mock.ANY, auth=mock.ANY, timeout=mock.ANY)
+                headers=mock.ANY, timeout=mock.ANY)
 
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
@@ -1094,13 +1085,13 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
 
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
 
             response = self.sift_client.get_session_decisions('example_user','example_session')
             mock_get.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/example_user/sessions/example_session/decisions',
-                headers=mock.ANY, auth=mock.ANY, timeout=mock.ANY)
+                headers=mock.ANY, timeout=mock.ANY)
 
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
@@ -1113,17 +1104,33 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
 
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.return_value = mock_response
 
             response = self.sift_client.get_content_decisions('example_user', 'example_content')
             mock_get.assert_called_with(
                 'https://api3.siftscience.com/v3/accounts/ACCT/users/example_user/content/example_content/decisions',
-                headers=mock.ANY, auth=mock.ANY, timeout=mock.ANY)
+                headers=mock.ANY, timeout=mock.ANY)
 
             assert(isinstance(response, sift.client.Response))
             assert(response.is_ok())
             assert(response.body['decisions']['content_abuse']['decision']['id'] == 'content_looks_bad_content_abuse')
+
+    def test_provided_session(self):
+        session = mock.Mock()
+        client = sift.Client(api_key=self.test_key, account_id=self.account_id, session=session)
+
+        mock_response = mock.Mock()
+        mock_response.content = '{"status": 0, "error_message": "OK"}'
+        mock_response.json.return_value = json.loads(mock_response.content)
+        mock_response.status_code = 200
+        mock_response.headers = response_with_data_header()
+        session.post.return_value = mock_response
+
+        event = '$transaction'
+        client.track(event, valid_transaction_properties())
+        session.post.assert_called_once()
+
 
 def main():
     unittest.main()

--- a/tests/test_client_v203.py
+++ b/tests/test_client_v203.py
@@ -117,7 +117,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.track(event, valid_transaction_properties())
             mock_post.assert_called_with(
@@ -139,7 +139,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client_v204.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client_v204.track(
                 event, valid_transaction_properties(), timeout=test_timeout, version='203')
@@ -160,10 +160,10 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_post:
-            mock_post.return_value = mock_response
+        with mock.patch.object(self.sift_client_v204.session, 'get') as mock_get:
+            mock_get.return_value = mock_response
             response = self.sift_client_v204.score('12345', version='203')
-            mock_post.assert_called_with(
+            mock_get.assert_called_with(
                 'https://api.siftscience.com/v203/score/12345',
                 params={'api_key': self.test_key},
                 headers=mock.ANY,
@@ -180,10 +180,10 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_post:
-            mock_post.return_value = mock_response
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
+            mock_get.return_value = mock_response
             response = self.sift_client.score('12345', test_timeout)
-            mock_post.assert_called_with(
+            mock_get.assert_called_with(
                 'https://api.siftscience.com/v203/score/12345',
                 params={'api_key': self.test_key},
                 headers=mock.ANY,
@@ -201,7 +201,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.track(
                 event, valid_transaction_properties(), return_score=True)
@@ -224,7 +224,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.label(user_id, valid_label_properties())
             properties = {
@@ -252,7 +252,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client_v204.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client_v204.label(
                 user_id, valid_label_properties(), test_timeout, version='203')
@@ -277,7 +277,7 @@ class TestSiftPythonClient(unittest.TestCase):
         user_id = '54321'
         mock_response = mock.Mock()
         mock_response.status_code = 204
-        with mock.patch('requests.delete') as mock_delete:
+        with mock.patch.object(self.sift_client.session, 'delete') as mock_delete:
             mock_delete.return_value = mock_response
             response = self.sift_client.unlabel(user_id)
             mock_delete.assert_called_with(
@@ -300,7 +300,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
             user_id = u'23056'
 
-            with mock.patch('requests.post') as mock_post:
+            with mock.patch.object(self.sift_client.session, 'post') as mock_post:
                 mock_post.return_value = mock_response
                 assert(
                     self.sift_client.track(
@@ -310,15 +310,15 @@ class TestSiftPythonClient(unittest.TestCase):
                     self.sift_client.label(
                         user_id,
                         valid_label_properties()))
-            with mock.patch('requests.get') as mock_post:
-                mock_post.return_value = mock_response
+            with mock.patch.object(self.sift_client.session, 'get') as mock_get:
+                mock_get.return_value = mock_response
                 assert(self.sift_client.score(user_id))
 
     def test_unlabel_user_with_special_chars_ok(self):
         user_id = "54321=.-_+@:&^%!$"
         mock_response = mock.Mock()
         mock_response.status_code = 204
-        with mock.patch('requests.delete') as mock_delete:
+        with mock.patch.object(self.sift_client_v204.session, 'delete') as mock_delete:
             mock_delete.return_value = mock_response
             response = self.sift_client_v204.unlabel(user_id, version='203')
             mock_delete.assert_called_with(
@@ -336,7 +336,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
             response = self.sift_client.label(
                 user_id, valid_label_properties())
@@ -367,10 +367,10 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.json.return_value = json.loads(mock_response.content)
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
-        with mock.patch('requests.get') as mock_post:
-            mock_post.return_value = mock_response
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
+            mock_get.return_value = mock_response
             response = self.sift_client.score(user_id)
-            mock_post.assert_called_with(
+            mock_get.assert_called_with(
                 'https://api.siftscience.com/v203/score/%s' % urllib.quote(user_id),
                 params={'api_key': self.test_key},
                 headers=mock.ANY,
@@ -382,7 +382,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_exception_during_track_call(self):
         warnings.simplefilter("always")
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.side_effect = mock.Mock(
                 side_effect=requests.exceptions.RequestException("Failed"))
             try:
@@ -393,7 +393,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_exception_during_score_call(self):
         warnings.simplefilter("always")
-        with mock.patch('requests.get') as mock_get:
+        with mock.patch.object(self.sift_client.session, 'get') as mock_get:
             mock_get.side_effect = mock.Mock(
                 side_effect=requests.exceptions.RequestException("Failed"))
             try:
@@ -403,7 +403,7 @@ class TestSiftPythonClient(unittest.TestCase):
 
     def test_exception_during_unlabel_call(self):
         warnings.simplefilter("always")
-        with mock.patch('requests.delete') as mock_delete:
+        with mock.patch.object(self.sift_client.session, 'delete') as mock_delete:
             mock_delete.side_effect = mock.Mock(
                 side_effect=requests.exceptions.RequestException("Failed"))
             try:
@@ -420,7 +420,7 @@ class TestSiftPythonClient(unittest.TestCase):
         mock_response.status_code = 200
         mock_response.headers = response_with_data_header()
 
-        with mock.patch('requests.post') as mock_post:
+        with mock.patch.object(self.sift_client.session, 'post') as mock_post:
             mock_post.return_value = mock_response
 
             response = self.sift_client.track(


### PR DESCRIPTION
Addresses #64 

Enables connection pooling by default which should improve performance for the majority of users. Also allows users to provide their own session object with any customisation they'd prefer, like timeouts, retries, or explicit pooling support.