### PR TITLE
Add Python version classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(
 
     classifiers=[
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This will help projects that use Sift migrate from Python 2 to Python 3 since I believe tools like https://pypi.org/project/caniusepython3/ rely on this classifier to detect dependency readiness.

Based on https://github.com/SiftScience/sift-python/blob/master/CHANGES.md I see that this currently supports both Python 3 and 2.7.