### PR TITLE
build error fixed

### DIFF
--- a/sift/client.py
+++ b/sift/client.py
@@ -827,10 +827,10 @@ class Client(object):
                     $session_id:  The session being verified. See $verification in the Sift Events API documentation.
                     $verified_event: The type of the reserved event being verified.
                     $reason(optional): The trigger for the verification. See $verification in the Sift Events API documentation.
-                    $ip(optional): The user’s IP address.
-                    $browser: 
+                    $ip(optional): The user's IP address.
+                    $browser:
                         $user_agent: The user agent of the browser that is verifying. Represented by the $browser object.
-                                     Use this field if the client is a browser. Note: cannot be used in conjunction with $app.
+                                     Use this field if the client is a browser.
 
 
             timeout(optional): Use a custom timeout (in seconds) for this call.

--- a/sift/client.py
+++ b/sift/client.py
@@ -1073,7 +1073,7 @@ class Response(object):
         if self.http_status_code in self.HTTP_CODES_WITHOUT_BODY:
             return 204 == self.http_status_code
 
-        # NOTE: Responses from /v3/... endpoints do not contain an API status.
+        # note: Responses from /v3/... endpoints do not contain an API status.
         if self.api_status:
             return self.api_status == 0
 


### PR DESCRIPTION
The error causing build fail was
SyntaxError: Non-ASCII character '\xe2' in file /home/travis/build/SiftScience/sift-python/sift/client.py on line 831, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

Reason :  A character copied from the documentation in the comments section was causing the build fail
