### PR TITLE
Specify proper markdown and content type in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ except ImportError:
 here = os.path.abspath(os.path.dirname(__file__))
 
 try:
-    README = open(os.path.join(here, 'README.rst')).read()
-    CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
+    README = open(os.path.join(here, 'README.md')).read()
+    CHANGES = open(os.path.join(here, 'CHANGES.md')).read()
 except Exception:
     README = ''
     CHANGES = ''
@@ -28,6 +28,7 @@ setup(
 
     author='Sift Science',
     author_email='support@siftscience.com',
+    long_description_content_type="text/markdown",
     long_description=README + '\n\n' + CHANGES,
 
     packages=['sift'],


### PR DESCRIPTION
This fixes the display of the description on PyPI, and fixes uploads via Twine.

Screenshot of proper description rendering:
<img width="1181" alt="Screen Shot 2022-11-09 at 7 24 05 PM" src="https://user-images.githubusercontent.com/94024022/200970553-3d8d6168-1b6d-4331-b72f-7cc2ac7b7afe.png">
