### PR TITLE
Verification endpoints implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ send_properties = {
 	"$verification_type": "$email",
 	"$brand_name": "MyTopBrand",
 	"$language": "en",
-	"$site_country": "Country Name",
+	"$site_country": "IN",
 	"$event": {
 		"$session_id": "SOME_SESSION_ID",
 		"$verified_event": "$login",

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ except sift.client.ApiException:
     # request failed
     pass
 
-# The resend call generates a new OTP and sends it to the original recipient with the same settings
+# The resend call generates a new OTP and sends it to the original recipient with the same settings.
 resend_properties = {
 	"$user_id": "billy_jones_301",
 	"$verified_event": "$login",

--- a/README.md
+++ b/README.md
@@ -183,8 +183,57 @@ try:
 except sift.client.ApiException:
     # request failed
     pass
-```
 
+# The send call triggers the generation of a OTP code that is stored by Sift and email/sms the code to the user.
+send_properties = {
+	"$user_id": "billy_jones_301",
+	"$send_to": "billy_jones_301@gmail.com",
+	"$verification_type": "$email",
+	"$brand_name": "MyTopBrand",
+	"$language": "en",
+	"$event": {
+		"$session_id": "SOME_SESSION_ID",
+		"$verified_event": "$login",
+		"$verified_entity_id": "SOME_SESSION_ID",
+		"$reason": "$automated_rule",
+		"$ip": "192.168.1.1",
+		"$browser": {
+			"$user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36"
+		}
+	}
+}
+try:
+    response = client.verification_send(send_properties)
+except sift.client.ApiException:
+    # request failed
+    pass
+
+# The resend call generates a new OTP and sends it to the original recipient with the same settings
+resend_properties = {
+	"$user_id": "billy_jones_301",
+	"$verified_event": "$login",
+	"$verified_entity_id": "SOME_SESSION_ID"
+}
+try:
+    response = client.verification_resend(resend_properties)
+except sift.client.ApiException:
+    # request failed
+    pass
+
+# The check call is used for verifying the OTP provided by the end user to Sift.
+check_properties = {
+	"$user_id": "billy_jones_301",
+    "$code": 123456,
+	"$verified_event": "$login",
+	"$verified_entity_id": "SOME_SESSION_ID"
+}
+try:
+    response = client.verification_check(check_properties)
+except sift.client.ApiException:
+    # request failed
+    pass
+
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ send_properties = {
 	"$verification_type": "$email",
 	"$brand_name": "MyTopBrand",
 	"$language": "en",
+	"$site_country": "Country Name",
 	"$event": {
 		"$session_id": "SOME_SESSION_ID",
 		"$verified_event": "$login",

--- a/sift/client.py
+++ b/sift/client.py
@@ -944,7 +944,7 @@ class Client(object):
             properties: 
 
                 $user_id: User ID of user being verified, e.g. johndoe123.
-                $verified_event: This will be the event type that triggered the verification.
+                $verified_event(optional): This will be the event type that triggered the verification.
                 $verified_entity_id(optional): The ID of the entity impacted by the event being verified.
 
             timeout(optional): Use a custom timeout (in seconds) for this call.

--- a/sift/client.py
+++ b/sift/client.py
@@ -22,6 +22,8 @@ import sift.version
 
 API_URL = 'https://api.siftscience.com'
 API3_URL = 'https://api3.siftscience.com'
+API_URL_VERIFICATION = 'https://api.sift.com/v1/verification/'
+
 DECISION_SOURCES = ['MANUAL_REVIEW', 'AUTOMATED_RULE', 'CHARGEBACK']
 
 
@@ -180,7 +182,6 @@ class Client(object):
         if include_score_percentiles:
             field_types = ['SCORE_PERCENTILES']
             params['fields'] = ','.join(field_types)
-
         try:
             response = self.session.post(
                 path,
@@ -485,7 +486,6 @@ class Client(object):
 
         self._validate_apply_decision_request(properties, user_id)
         url = self._user_decisions_url(self.account_id, user_id)
-
         try:
             return Response(self.session.post(
                 url,
@@ -524,7 +524,6 @@ class Client(object):
         self._validate_apply_decision_request(properties, user_id)
 
         url = self._order_apply_decisions_url(self.account_id, user_id, order_id)
-
         try:
             return Response(self.session.post(
                 url,
@@ -788,7 +787,6 @@ class Client(object):
             timeout = self.timeout
 
         url = self._psp_merchant_id_url(self.account_id, merchant_id)
-
         try:
             return Response(self.session.put(
                 url,
@@ -854,6 +852,196 @@ class Client(object):
         except requests.exceptions.RequestException as e:
             raise ApiException(str(e), url)
 
+    def verification_send(self, properties, timeout=None,  version=None):
+        """The send call triggers the generation of a OTP code that is stored by Sift and email/sms the code to the user.
+        This call is blocking. Check out https://sift.com/developers/docs/python/verification-api/send
+        for more information on our send response structure.
+
+        Args:
+
+            properties: 
+
+                $user_id: User ID of user being verified, e.g. johndoe123.
+                $send_to: The phone / email to send the OTP to.
+                $verification_type: The channel used for verification. Should be either $email or $sms.
+                $brand_name(optional): Name of the brand of product or service the user interacts with.
+                $language(optional): Language of the content of the web site.
+                $site_country(optional): Country of the content of the site.
+                $event: 
+                    $session_id:  The session being verified. See $verification in the Sift Events API documentation.
+                    $verified_event: The type of the reserved event being verified.
+                    $reason(optional): The trigger for the verification. See $verification in the Sift Events API documentation.
+                    $ip(optional): The user's IP address.
+                    $browser:
+                        $user_agent: The user agent of the browser that is verifying. Represented by the $browser object.
+                                     Use this field if the client is a browser.
+
+
+            timeout(optional): Use a custom timeout (in seconds) for this call.
+
+            version(optional): Use a different version of the Sift Science API for this call.
+
+        Returns:
+            A sift.client.Response object if the send call succeeded, or raises an ApiException.
+        """
+
+        if timeout is None:
+            timeout = self.timeout
+
+        self._validate_send_request(properties)
+
+        url = self._verification_send_url()
+
+        try:
+            return Response(self.session.post(
+                url,
+                data=json.dumps(properties),
+                auth=requests.auth.HTTPBasicAuth(self.api_key, ''),
+                headers={'Content-type': 'application/json',
+                         'Accept': '*/*',
+                         'User-Agent': self._user_agent()},
+                timeout=timeout))
+
+        except requests.exceptions.RequestException as e:
+            raise ApiException(str(e), url)  
+
+    def _validate_send_request(self, properties):
+        """ This method is used to validate arguments passed to the send method. """
+
+        if not isinstance(properties, dict):
+            raise TypeError("properties must be a dict")
+        elif not properties:
+            raise ValueError("properties dictionary may not be empty")
+
+        user_id = properties.get('$user_id')
+        _assert_non_empty_unicode(user_id, 'user_id', error_cls=ValueError)
+
+        send_to = properties.get('$send_to')
+        _assert_non_empty_unicode(send_to, 'send_to', error_cls=ValueError)
+
+        verification_type = properties.get('$verification_type')
+        _assert_non_empty_unicode(
+            verification_type, 'verification_type', error_cls=ValueError)
+
+        event = properties.get('$event')
+        if not isinstance(event, dict):
+            raise TypeError("$event must be a dict")
+        elif not event:
+            raise ValueError("$event dictionary may not be empty")
+
+        session_id = event.get('$session_id')
+        _assert_non_empty_unicode(
+            session_id, 'session_id', error_cls=ValueError)
+    
+    def verification_resend(self, properties, timeout=None,  version=None):
+        """A user can ask for a new OTP (one-time password) if they haven’t received the previous one,
+        or in case the previous OTP expired.
+        This call is blocking. Check out https://sift.com/developers/docs/python/verification-api/resend
+        for more information on our send response structure.
+
+        Args:
+
+            properties: 
+
+                $user_id: User ID of user being verified, e.g. johndoe123.
+                $verified_event: This will be the event type that triggered the verification.
+                $verified_entity_id(optional): The ID of the entity impacted by the event being verified.
+
+            timeout(optional): Use a custom timeout (in seconds) for this call.
+
+            version(optional): Use a different version of the Sift Science API for this call.
+
+        Returns:
+            A sift.client.Response object if the send call succeeded, or raises an ApiException.
+        """
+
+        if timeout is None:
+            timeout = self.timeout
+
+        self._validate_resend_request(properties)
+
+        url = self._verification_resend_url()
+
+        try:
+            return Response(self.session.post(
+                url,
+                data=json.dumps(properties),
+                auth=requests.auth.HTTPBasicAuth(self.api_key, ''),
+                headers={'Content-type': 'application/json',
+                         'Accept': '*/*',
+                         'User-Agent': self._user_agent()},
+                timeout=timeout))
+
+        except requests.exceptions.RequestException as e:
+            raise ApiException(str(e), url)  
+
+    def _validate_resend_request(self, properties):
+        """ This method is used to validate arguments passed to the send method. """
+
+        if not isinstance(properties, dict):
+            raise TypeError("properties must be a dict")
+        elif not properties:
+            raise ValueError("properties dictionary may not be empty")
+
+        user_id = properties.get('$user_id')
+        _assert_non_empty_unicode(user_id, 'user_id', error_cls=ValueError)
+    
+    def verification_check(self, properties, timeout=None,  version=None):
+            """The verification_check call is used for checking the OTP provided by the end user to Sift. 
+            Sift then compares the OTP, checks rate limits and responds with a decision whether the user should be able to proceed or not.
+            This call is blocking. Check out https://sift.com/developers/docs/python/verification-api/check
+            for more information on our check response structure.
+
+            Args:
+
+                properties:
+                    $user_id: User ID of user being verified, e.g. johndoe123.
+                    $code: The code the user sent to the customer for validation..
+                    $verified_event(optional): This will be the event type that triggered the verification. 
+                    $verified_entity_id(optional): The ID of the entity impacted by the event being verified.
+
+                timeout(optional): Use a custom timeout (in seconds) for this call.
+                version(optional): Use a different version of the Sift Science API for this call.
+
+            Returns:
+                A sift.client.Response object if the check call succeeded, or raises
+                an ApiException.
+            """
+            if timeout is None:
+                timeout = self.timeout
+
+            self._validate_check_request(properties)
+
+            url = self._verification_check_url()
+
+            try:
+                return Response(self.session.post(
+                    url,
+                    data=json.dumps(properties),
+                    auth=requests.auth.HTTPBasicAuth(self.api_key, ''),
+                    headers={'Content-type': 'application/json',
+                            'Accept': '*/*',
+                            'User-Agent': self._user_agent()},
+                    timeout=timeout))
+
+            except requests.exceptions.RequestException as e:
+                raise ApiException(str(e), url)
+
+    def _validate_check_request(self, properties):
+        """ This method is used to validate arguments passed to the check method. """
+
+        if not isinstance(properties, dict):
+            raise TypeError("properties must be a dict")
+        elif not properties:
+            raise ValueError("properties dictionary may not be empty")
+
+        user_id = properties.get('$user_id')
+        _assert_non_empty_unicode(user_id, 'user_id', error_cls=ValueError)
+
+        otp_code = properties.get('$code')
+        if otp_code is None:
+            raise ValueError("code is required")
+  
     def _user_agent(self):
         return 'SiftScience/v%s sift-python/%s' % (sift.version.API_VERSION, sift.version.VERSION)
 
@@ -912,6 +1100,14 @@ class Client(object):
         return (self.url + '/v3/accounts/%s/psp_management/merchants/%s' %
                 (_quote_path(account_id), _quote_path(merchant_id)))
 
+    def _verification_send_url(self):
+        return (API_URL_VERIFICATION + 'send')
+    
+    def _verification_resend_url(self):
+        return (API_URL_VERIFICATION + 'resend')
+    
+    def _verification_check_url(self):
+        return (API_URL_VERIFICATION + 'check')
 
 class Response(object):
     HTTP_CODES_WITHOUT_BODY = [204, 304]

--- a/tests/test_verification_apis.py
+++ b/tests/test_verification_apis.py
@@ -1,0 +1,167 @@
+from decimal import Decimal
+import unittest
+import warnings
+import json
+import mock
+import sift
+import sys
+
+import requests.exceptions
+if sys.version_info[0] < 3:
+    import six.moves.urllib as urllib 
+else:
+    import urllib.parse
+
+def valid_verification_send_properties():
+    return {
+        "$user_id": "billy_jones_301",
+        "$send_to": "billy_jones_301@gmail.com",
+        "$verification_type": "$email",
+        "$brand_name": "MyTopBrand",
+        "$language": "en",
+        "$event": {
+            "$session_id": "SOME_SESSION_ID",
+            "$verified_event": "$login",
+            "$verified_entity_id": "SOME_SESSION_ID",
+            "$reason": "$automated_rule",
+            "$ip": "192.168.1.1",
+            "$browser": {
+                "$user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36"
+            }
+    }
+}
+
+def valid_verification_resend_properties():
+    return {
+        "$user_id": "billy_jones_301",
+        "$verified_event": "$login",
+        "$verified_entity_id": "SOME_SESSION_ID"
+    }
+
+def valid_verification_check_properties():
+    return {
+        "$user_id": "billy_jones_301",
+        "$code": "123456",
+        "$verified_event": "$login",
+        "$verified_entity_id": "SOME_SESSION_ID"
+    }
+
+def response_with_data_header():
+    return {
+        "content-length": 1,
+        "content-type": "application/json; charset=UTF-8"
+    }
+
+class TestVerificationAPI(unittest.TestCase):
+    def setUp(self):
+        self.test_key = "a_fake_test_api_key"
+        self.sift_client = sift.Client(self.test_key)
+
+    def test_verification_send_ok(self):
+        mock_response = mock.Mock()
+        
+        send_response_json = """
+        {
+            "status": 0,
+            "error_message": "OK",
+            "sent_at": 1689316615034,
+            "segment_id": "143",
+            "segment_name": "Verification Template",
+            "brand_name": "",
+            "site_country": "",
+            "content_language": "",
+            "http_status_code": 200
+        }
+        """
+        
+        mock_response.content = send_response_json
+        mock_response.json.return_value = json.loads(mock_response.content)
+        mock_response.status_code = 200
+        mock_response.headers = response_with_data_header()
+        with mock.patch.object(self.sift_client.session, "post") as mock_post:
+            mock_post.return_value = mock_response
+            response = self.sift_client.verification_send(valid_verification_send_properties())
+            data = json.dumps(valid_verification_send_properties())
+            mock_post.assert_called_with(
+                "https://api.sift.com/v1/verification/send",
+                auth=mock.ANY,
+                data=data,
+                headers=mock.ANY,
+                timeout=mock.ANY)
+            self.assertIsInstance(response, sift.client.Response)
+            assert(response.is_ok())
+            assert(response.api_status == 0)
+            assert(response.api_error_message == "OK")
+
+    def test_verification_resend_ok(self):
+        mock_response = mock.Mock()
+        
+        resend_response_json = """
+        {
+            "status": 0,
+            "error_message": "OK",
+            "sent_at": 1689316615034,
+            "segment_id": "143",
+            "segment_name": "Verification Template",
+            "brand_name": "",
+            "site_country": "",
+            "content_language": "",
+            "http_status_code": 200
+        }
+        """
+        
+        mock_response.content = resend_response_json
+        mock_response.json.return_value = json.loads(mock_response.content)
+        mock_response.status_code = 200
+        mock_response.headers = response_with_data_header()
+        with mock.patch.object(self.sift_client.session, "post") as mock_post:
+            mock_post.return_value = mock_response
+            response = self.sift_client.verification_resend(valid_verification_resend_properties())
+            data = json.dumps(valid_verification_resend_properties())
+            mock_post.assert_called_with(
+                "https://api.sift.com/v1/verification/resend",
+                auth=mock.ANY,
+                data=data,
+                headers=mock.ANY,
+                timeout=mock.ANY)
+            self.assertIsInstance(response, sift.client.Response)
+            assert(response.is_ok())
+            assert(response.api_status == 0)
+            assert(response.api_error_message == "OK")        
+    
+    def test_verification_check_ok(self):
+        mock_response = mock.Mock()
+        
+        check_response_json = """
+        {
+            "status": 0,
+            "error_message": "OK",
+            "checked_at": 1689316615034,
+            "http_status_code": 200
+        }
+        """
+        
+        mock_response.content = check_response_json
+        mock_response.json.return_value = json.loads(mock_response.content)
+        mock_response.status_code = 200
+        mock_response.headers = response_with_data_header()
+        with mock.patch.object(self.sift_client.session, "post") as mock_post:
+            mock_post.return_value = mock_response
+            response = self.sift_client.verification_check(valid_verification_check_properties())
+            data = json.dumps(valid_verification_check_properties())
+            mock_post.assert_called_with(
+                "https://api.sift.com/v1/verification/check",
+                auth=mock.ANY,
+                data=data,
+                headers=mock.ANY,
+                timeout=mock.ANY)
+            self.assertIsInstance(response, sift.client.Response)
+            assert(response.is_ok())
+            assert(response.api_status == 0)
+            assert(response.api_error_message == "OK") 
+
+def main():
+    unittest.main()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_verification_apis.py
+++ b/tests/test_verification_apis.py
@@ -7,10 +7,6 @@ import sift
 import sys
 
 import requests.exceptions
-if sys.version_info[0] < 3:
-    import six.moves.urllib as urllib 
-else:
-    import urllib.parse
 
 def valid_verification_send_properties():
     return {
@@ -19,6 +15,7 @@ def valid_verification_send_properties():
         "$verification_type": "$email",
         "$brand_name": "MyTopBrand",
         "$language": "en",
+        "$site_country": "Country Name",
         "$event": {
             "$session_id": "SOME_SESSION_ID",
             "$verified_event": "$login",

--- a/tests/test_verification_apis.py
+++ b/tests/test_verification_apis.py
@@ -15,7 +15,7 @@ def valid_verification_send_properties():
         "$verification_type": "$email",
         "$brand_name": "MyTopBrand",
         "$language": "en",
-        "$site_country": "Country Name",
+        "$site_country": "IN",
         "$event": {
             "$session_id": "SOME_SESSION_ID",
             "$verified_event": "$login",


### PR DESCRIPTION
## Purpose
The verification APIs are implemented (send/resend/check)
## Summary
Added wrappers for the following APIs

- verification/send
- verification/resend
- verification/check

## Testing
Changes covered in Unit Test for the above API wrappers(path/tests/test_verification_apis.py)

verification/send (Real Call)
![image](https://github.com/SiftScience/sift-python/assets/135820493/4b9e92b0-a4f4-45de-a973-d63e2da4bc03)

verification/resend
![image](https://github.com/SiftScience/sift-python/assets/135820493/ebf68b13-5a65-4c12-85de-d9a5049dc1dc)

verification/check
![image](https://github.com/SiftScience/sift-python/assets/135820493/f08b85af-0199-4a0d-9c82-5c5cb22cae9b)


## Checklist
- [X] The change was thoroughly tested manually
- [X] The change was covered with unit tests
- [X] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable)
- [X] New functionality is reflected in README
