### PR TITLE
Msue 191 integration testing app new

### DIFF
--- a/test_integration_app/decisions_api/__init__.py
+++ b/test_integration_app/decisions_api/__init__.py
@@ -1,0 +1,1 @@
+from decisions_api import test_decisions_api

--- a/test_integration_app/decisions_api/test_decisions_api.py
+++ b/test_integration_app/decisions_api/test_decisions_api.py
@@ -1,0 +1,66 @@
+import sift
+import globals
+
+from os import environ as env
+
+class DecisionAPI():
+    # Get the value of API_KEY from environment variable
+    api_key = env['API_KEY']
+    account_id = env['ACCOUNT_ID']
+    client = sift.Client(api_key = api_key, account_id = account_id)
+    globals.initialize()
+    user_id = globals.user_id
+
+    def apply_user_decision(self):
+        applyDecisionRequest = {
+            "decision_id"     : "block_user_payment_abuse",
+            "source"          : "MANUAL_REVIEW",
+            "analyst"         : "analyst@example.com",
+            "description"     : "User linked to three other payment abusers and ordering high value items"
+        }
+        
+        return self.client.apply_user_decision(self.user_id, applyDecisionRequest)
+
+    def apply_order_decision(self):
+        applyOrderDecisionRequest = {
+            "decision_id"   : "block_order_payment_abuse",
+            "source"    : "AUTOMATED_RULE",
+            "description"   : "Auto block pending order as score exceeded risk threshold of 90"
+        }
+        
+        return self.client.apply_order_decision(self.user_id, "ORDER-1234567", applyOrderDecisionRequest)
+
+    def apply_session_decision(self):
+        applySessionDecisionRequest = {
+            "decision_id"   : "session_looks_fraud_account_takover",
+            "source"    : "MANUAL_REVIEW",
+            "analyst"   : "analyst@example.com",
+            "description"   : "compromised account reported to customer service"
+        }
+        
+        return self.client.apply_session_decision(self.user_id, "session_id", applySessionDecisionRequest)
+
+    def apply_content_decision(self):
+        applyContentDecisionRequest = {
+            "decision_id"    : "content_looks_fraud_content_abuse",
+            "source"         : "MANUAL_REVIEW",
+            "analyst"       : "analyst@example.com",
+            "description"    : "fraudulent listing"
+        }
+        
+        return self.client.apply_content_decision(self.user_id, "content_id", applyContentDecisionRequest)
+
+    def get_user_decisions(self):
+        return self.client.get_user_decisions(self.user_id)
+
+    def get_order_decisions(self):
+        return self.client.get_order_decisions("ORDER-1234567")
+
+    def get_content_decisions(self):
+        return self.client.get_content_decisions(self.user_id, "CONTENT_ID")
+
+    def get_session_decisions(self):
+        return self.client.get_session_decisions(self.user_id, "SESSION_ID")
+        
+    def get_decisions(self):
+        return self.client.get_decisions(entity_type='user', limit=10, start_from=5, abuse_types='legacy,payment_abuse')

--- a/test_integration_app/events_api/__init__.py
+++ b/test_integration_app/events_api/__init__.py
@@ -1,0 +1,1 @@
+from events_api import test_events_api

--- a/test_integration_app/events_api/test_events_api.py
+++ b/test_integration_app/events_api/test_events_api.py
@@ -1,0 +1,1307 @@
+import sift
+import globals
+
+from os import environ as env
+
+class EventsAPI():
+  # Get the value of API_KEY from environment variable
+  api_key = env['API_KEY']
+  client = sift.Client(api_key = api_key)
+  globals.initialize()
+  user_id = globals.user_id
+  user_email = globals.user_email
+  
+  def add_item_to_cart(self):
+    add_item_to_cart_properties = {       
+      # Required Fields
+      "$user_id"           : self.user_id,
+      # Supported Fields
+      "$session_id" : "gigtleqddo84l8cm15qe4il",
+      "$item"       : {
+        "$item_id"        : "B004834GQO",
+        "$product_title"  : "The Slanket Blanket-Texas Tea",
+        "$price"          : 39990000, # $39.99
+        "$currency_code"  : "USD",
+        "$upc"            : "6786211451001",
+        "$sku"            : "004834GQ",
+        "$brand"          : "Slanket",
+        "$manufacturer"   : "Slanket",
+        "$category"       : "Blankets & Throws",
+        "$tags"           : ["Awesome", "Wintertime specials"],
+        "$color"          : "Texas Tea",
+        "$quantity"       : 16
+      },
+      "$brand_name"   : "sift",
+      "$site_domain"  : "sift.com",
+      "$site_country" : "US",
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent"       : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$add_item_to_cart", add_item_to_cart_properties)
+    
+
+  def add_promotion(self):
+    add_promotion_properties = {
+      # Required fields.
+      "$user_id"    : self.user_id,
+      # Supported fields.
+      "$promotions" : [
+        # Example of a promotion for monetary discounts off good or services
+        {
+          "$promotion_id"     : "NewRideDiscountMay2016",
+          "$status"           : "$success",
+          "$description"      : "$5 off your first 5 rides",
+          "$referrer_user_id" : "elon-m93903",
+          "$discount"         : {
+            "$amount"         : 5000000,  # $5
+            "$currency_code"  : "USD"
+          }
+        }
+      ],
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$add_promotion", add_promotion_properties)
+
+  def chargeback(self):
+    # Sample $chargeback event
+    chargeback_properties = {
+      # Required Fields
+      "$order_id"          : "ORDER-123124124",
+      "$transaction_id"    : "719637215",
+      # Recommended Fields
+      "$user_id"           : self.user_id,
+      "$chargeback_state"  : "$lost",
+      "$chargeback_reason" : "$duplicate"
+    }
+    return self.client.track("$chargeback", chargeback_properties)
+
+  def content_status(self):
+    # Sample $content_status event
+    content_status_properties = {
+      # Required Fields
+      "$user_id"    : self.user_id,
+      "$content_id" : "9671500641",
+      "$status"     : "$paused",
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$content_status", content_status_properties)
+
+  def create_account(self):
+    # Sample $create_account event
+    create_account_properties = {
+      # Required Fields
+      "$user_id"    : self.user_id,
+      # Supported Fields
+      "$session_id"                : "gigtleqddo84l8cm15qe4il",
+      "$user_email"                : self.user_email,
+      "$verification_phone_number" : "+123456789012",
+      "$name"                      : "Bill Jones",
+      "$phone"                     : "1-415-555-6040",
+      "$referrer_user_id"          : "janejane101",
+      "$payment_methods"           : [
+        {
+          "$payment_type"    : "$credit_card",
+          "$card_bin"        : "542486",
+          "$card_last4"      : "4444"
+        }
+      ],
+      "$billing_address"  : {
+        "$name"         : "Bill Jones",
+        "$phone"        : "1-415-555-6040",
+        "$address_1"    : "2100 Main Street",
+        "$address_2"    : "Apt 3B",
+        "$city"         : "New London",
+        "$region"       : "New Hampshire",
+        "$country"      : "US",
+        "$zipcode"      : "03257"
+      },
+      "$shipping_address"  : {
+        "$name"          : "Bill Jones",
+        "$phone"         : "1-415-555-6041",
+        "$address_1"     : "2100 Main Street",
+        "$address_2"     : "Apt 3B",
+        "$city"          : "New London",
+        "$region"        : "New Hampshire",
+        "$country"       : "US",
+        "$zipcode"       : "03257"
+      },
+      "$promotions"       : [
+        {
+          "$promotion_id"     : "FriendReferral",
+          "$status"           : "$success",
+          "$referrer_user_id" : "janejane102",
+          "$credit_point"     : {
+            "$amount"              : 100,
+            "$credit_point_type"   : "account karma"
+          }
+        }
+      ],
+      "$social_sign_on_type"   : "$twitter",
+      "$account_types"         : ["merchant", "premium"],
+
+      # Suggested Custom Fields
+      "twitter_handle"          : "billyjones",
+      "work_phone"              : "1-347-555-5921",
+      "location"                : "New London, NH",
+      "referral_code"           : "MIKEFRIENDS",
+      "email_confirmed_status"  : "$pending",
+      "phone_confirmed_status"  : "$pending",
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    } 
+    return self.client.track("$create_account", create_account_properties)
+
+  def create_content_comment(self):
+    # Sample $create_content event for comments
+    comment_properties = {
+      # Required fields
+      "$user_id"                : self.user_id,
+      "$content_id"             : "comment-23412",
+
+      # Recommended fields
+      "$session_id"             : "a234ksjfgn435sfg",
+      "$status"                 : "$active",
+      "$ip"                     : "255.255.255.0",
+
+      # Required $comment object
+      "$comment"                : {
+        "$body"               : "Congrats on the new role!",
+        "$contact_email"      : "alex_301@domain.com",
+        "$parent_comment_id"  : "comment-23407",
+        "$root_content_id"    : "listing-12923213",
+        "$images"             : [
+          {
+            "$md5_hash"       : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"           : "https://www.domain.com/file.png",
+            "$description"    : "An old picture"
+          }
+        ]
+      },
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$create_content", comment_properties)
+
+  def create_content_listing(self):
+    # Sample $create_content event for listings
+    listing_properties = {
+      # Required fields
+      "$user_id"                : self.user_id,
+      "$content_id"             : "listing-23412",
+
+      # Recommended fields
+      "$session_id"             : "a234ksjfgn435sfg",
+      "$status"                 : "$active",
+      "$ip"                     : "255.255.255.0",
+
+      # Required $listing object
+      "$listing"                : {
+        "$subject"            : "2 Bedroom Apartment for Rent",
+        "$body"               : "Capitol Hill Seattle brand new condo. 2 bedrooms and 1 full bath.",
+        "$contact_email"      : "alex_301@domain.com",
+        "$contact_address"    : {
+          "$name"           : "Bill Jones",
+          "$phone"          : "1-415-555-6041",
+          "$city"           : "New London",
+          "$region"         : "New Hampshire",
+          "$country"        : "US",
+          "$zipcode"        : "03257"
+        },
+        "$locations"          : [
+          {
+            "$city"           : "Seattle",
+            "$region"         : "Washington",
+            "$country"        : "US",
+            "$zipcode"        : "98112"
+          }
+        ],
+        "$listed_items"       : [
+          {
+            "$price"          : 2950000000, # $2950.00
+            "$currency_code"  : "USD",
+            "$tags"           : ["heat", "washer/dryer"]
+          }
+        ],
+        "$images"             : [
+          {
+            "$md5_hash"       : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"           : "https://www.domain.com/file.png",
+            "$description"    : "Billy's picture"
+          }
+        ],
+        "$expiration_time"    : 1549063157000 # UNIX timestamp in milliseconds
+      },
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$create_content", listing_properties)
+
+  def create_content_message(self):
+    # Sample $create_content event for messages
+    message_properties = {
+        # Required fields
+        "$user_id"                 : self.user_id,
+        "$content_id"              : "message-23412",
+
+        # Recommended fields
+        "$session_id"              : "a234ksjfgn435sfg",
+        "$status"                  : "$active",
+        "$ip"                      : "255.255.255.0",
+
+        # Required $message object
+        "$message"                 : {
+          "$body"                : "Let’s meet at 5pm",
+          "$contact_email"       : "alex_301@domain.com",
+          "$recipient_user_ids"  : ["fy9h989sjphh71"],
+          "$images"              : [
+            {
+              "$md5_hash"        : "0cc175b9c0f1b6a831c399e269772661",
+              "$link"            : "https://www.domain.com/file.png",
+              "$description"     : "My hike today!"
+            }
+          ]
+        },
+
+        # Send this information from a BROWSER client.
+        "$browser"      : {
+          "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+          "$accept_language"  : "en-US",
+          "$content_language" : "en-GB"
+        }
+    }
+    return self.client.track("$create_content", message_properties)
+
+  def create_content_post(self):
+    # Sample $create_content event for posts
+    post_properties = {
+      # Required fields
+      "$user_id"              : self.user_id,
+      "$content_id"           : "post-23412",
+
+      # Recommended fields
+      "$session_id"           : "a234ksjfgn435sfg",
+      "$status"               : "$active",
+      "$ip"                   : "255.255.255.0",
+
+      # Required $post object
+      "$post"                 : {
+        "$subject"          : "My new apartment!",
+        "$body"             : "Moved into my new apartment yesterday.",
+        "$contact_email"    : "alex_301@domain.com",
+        "$contact_address"  : {
+          "$name"         : "Bill Jones",
+          "$city"         : "New London",
+          "$region"       : "New Hampshire",
+          "$country"      : "US",
+          "$zipcode"      : "03257"
+        },
+        "$locations"        : [
+          {
+            "$city"         : "Seattle",
+            "$region"       : "Washington",
+            "$country"      : "US",
+            "$zipcode"      : "98112"
+          }
+        ],
+        "$categories"       : ["Personal"],
+        "$images"           : [
+          {
+            "$md5_hash"     : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"         : "https://www.domain.com/file.png",
+            "$description"  : "View from the window!"
+          }
+        ],
+        "$expiration_time"  : 1549063157000 # UNIX timestamp in milliseconds
+      },
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$create_content", post_properties)
+
+  def create_content_profile(self):
+    # Sample $create_content event for reviews
+    profile_properties = {
+      # Required fields
+      "$user_id"              : self.user_id,
+      "$content_id"           : "profile-23412",
+
+      # Recommended fields
+      "$session_id"           : "a234ksjfgn435sfg",
+      "$status"               : "$active",
+      "$ip"                   : "255.255.255.0",
+
+      # Required $profile object
+      "$profile"              : {
+        "$body"             : "Hi! My name is Alex and I just moved to New London!",
+        "$contact_email"    : "alex_301@domain.com",
+        "$contact_address"  : {
+          "$name"         : "Alex Smith",
+          "$phone"        : "1-415-555-6041",
+          "$city"         : "New London",
+          "$region"       : "New Hampshire",
+          "$country"      : "US",
+          "$zipcode"      : "03257"
+        },
+        "$images"           : [
+          {
+            "$md5_hash"     : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"         : "https://www.domain.com/file.png",
+            "$description"  : "Alex's picture"
+          }
+        ],
+        "$categories"       : [
+          "Friends",
+          "Long-term dating"
+        ]
+      },
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$create_content", profile_properties)
+
+  def create_content_review(self):
+    # Sample $create_content event for reviews
+    review_properties = {
+      # Required fields
+      "$user_id"                  : self.user_id,
+      "$content_id"               : "review-23412",
+
+      # Recommended fields
+      "$session_id"               : "a234ksjfgn435sfg",
+      "$status"                   : "$active",
+      "$ip"                       : "255.255.255.0",
+
+      # Required $review object
+      "$review"                   : {
+        "$subject"              : "Amazing Tacos!",
+        "$body"                 : "I ate the tacos.",
+        "$contact_email"        : "alex_301@domain.com",
+        "$locations"            : [
+          {
+            "$city"             : "Seattle",
+            "$region"           : "Washington",
+            "$country"          : "US",
+            "$zipcode"          : "98112"
+          }
+        ],
+        "$reviewed_content_id"  : "listing-234234",
+        "$images"               : [
+          {
+            "$md5_hash"         : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"             : "https://www.domain.com/file.png",
+            "$description"      : "Calamari tacos."
+          }
+        ],
+        "$rating" : 4.5
+      },
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$create_content", review_properties)
+
+  def create_order(self):
+    # Sample $create_order event
+    order_properties = {
+      # Required Fields
+      "$user_id"                   : self.user_id,
+      # Supported Fields
+      "$session_id"                : "gigtleqddo84l8cm15qe4il",
+      "$order_id"                  : "ORDER-28168441",
+      "$user_email"                : self.user_email,
+      "$verification_phone_number" : "+123456789012",
+      "$amount"                    : 115940000, # $115.94
+      "$currency_code"             : "USD",
+      "$billing_address"           : {
+        "$name"         : "Bill Jones",
+        "$phone"        : "1-415-555-6041",
+        "$address_1"    : "2100 Main Street",
+        "$address_2"    : "Apt 3B",
+        "$city"         : "New London",
+        "$region"       : "New Hampshire",
+        "$country"      : "US",
+        "$zipcode"      : "03257"
+      },
+      "$payment_methods"  : [
+        {
+          "$payment_type"    : "$credit_card",
+          "$payment_gateway" : "$braintree",
+          "$card_bin"        : "542486",
+          "$card_last4"      : "4444"
+        }
+      ],
+      "$ordered_from" : {
+        "$store_id"      : "123",
+        "$store_address" : {
+          "$name"       : "Bill Jones",
+          "$phone"      : "1-415-555-6040",
+          "$address_1"  : "2100 Main Street",
+          "$address_2"  : "Apt 3B",
+          "$city"       : "New London",
+          "$region"     : "New Hampshire",
+          "$country"    : "US",
+          "$zipcode"    : "03257"
+        }
+      },
+      "$brand_name"   : "sift",
+      "$site_domain"  : "sift.com",
+      "$site_country" : "US",
+      "$shipping_address"  : {
+        "$name"          : "Bill Jones",
+        "$phone"         : "1-415-555-6041",
+        "$address_1"     : "2100 Main Street",
+        "$address_2"     : "Apt 3B",
+        "$city"          : "New London",
+        "$region"        : "New Hampshire",
+        "$country"       : "US",
+        "$zipcode"       : "03257"
+      },
+      "$expedited_shipping"       : True,
+      "$shipping_method"          : "$physical",
+      "$shipping_carrier"         : "UPS",
+      "$shipping_tracking_numbers": ["1Z204E380338943508", "1Z204E380338943509"],
+      "$items"                    : [
+        {
+          "$item_id"        : "12344321",
+          "$product_title"  : "Microwavable Kettle Corn: Original Flavor",
+          "$price"          : 4990000, # $4.99
+          "$upc"            : "097564307560",
+          "$sku"            : "03586005",
+          "$brand"          : "Peters Kettle Corn",
+          "$manufacturer"   : "Peters Kettle Corn",
+          "$category"       : "Food and Grocery",
+          "$tags"           : ["Popcorn", "Snacks", "On Sale"],
+          "$quantity"       : 4
+        },
+        {
+          "$item_id"        : "B004834GQO",
+          "$product_title"  : "The Slanket Blanket-Texas Tea",
+          "$price"          : 39990000, # $39.99
+          "$upc"            : "6786211451001",
+          "$sku"            : "004834GQ",
+          "$brand"          : "Slanket",
+          "$manufacturer"   : "Slanket",
+          "$category"       : "Blankets & Throws",
+          "$tags"           : ["Awesome", "Wintertime specials"],
+          "$color"          : "Texas Tea",
+          "$quantity"       : 2
+        }
+      ],
+      # For marketplaces, use $seller_user_id to identify the seller
+      "$seller_user_id"     : "slinkys_emporium",
+
+      "$promotions"         : [
+        {
+          "$promotion_id" : "FirstTimeBuyer",
+          "$status"       : "$success",
+          "$description"  : "$5 off",
+          "$discount"     : {
+            "$amount"                   : 5000000,  # $5.00
+            "$currency_code"            : "USD",
+            "$minimum_purchase_amount"  : 25000000  # $25.00
+          }
+        }
+      ],
+
+      # Sample Custom Fields
+      "digital_wallet"      : "apple_pay", # "google_wallet", etc.
+      "coupon_code"         : "dollarMadness",
+      "shipping_choice"     : "FedEx Ground Courier",
+      "is_first_time_buyer" : False,
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$create_order", order_properties)
+    
+  def flag_content(self):
+    # Sample $flag_content event
+    flag_content_properties = {
+      # Required Fields
+      "$user_id"    : self.user_id, # content creator
+      "$content_id" : "9671500641",
+
+      # Supported Fields
+      "$flagged_by" : "jamieli89"
+    }
+    return self.client.track("$flag_content", flag_content_properties)
+      
+  def link_session_to_user(self):
+    # Sample $link_session_to_user event
+    link_session_to_user_properties = {
+      # Required Fields
+      "$user_id"    : self.user_id,
+      "$session_id" : "gigtleqddo84l8cm15qe4il"
+    }
+    return self.client.track("$link_session_to_user", link_session_to_user_properties)
+
+  def login(self):
+    # Sample $login event
+    login_properties = {
+      # Required Fields
+      "$user_id"      : self.user_id,
+      "$login_status" : "$failure",
+      "$session_id"   : "gigtleqddo84l8cm15qe4il",
+      "$ip"           : "128.148.1.135",
+
+      # Optional Fields
+      "$user_email"                : self.user_email,
+      "$verification_phone_number" : "+123456789012",
+      "$failure_reason"            : "$wrong_password",
+      "$username"                  : "billjones1@example.com",
+      "$account_types"             : ["merchant", "premium"],
+      "$social_sign_on_type"       : "$linkedin",
+      "$brand_name"                : "sift",
+      "$site_domain"               : "sift.com",
+      "$site_country"              : "US",
+
+      # Send this information with a login from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$login", login_properties)
+
+  def logout(self):
+    # Sample $logout event
+    logout_properties = {
+      # Required Fields
+      "$user_id"   : self.user_id,
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$logout", logout_properties)
+
+  def order_status(self):
+    # Sample $order_status event
+    order_properties = {
+      # Required Fields
+      "$user_id"          : self.user_id,
+      "$order_id"         : "ORDER-28168441",
+      "$order_status"     : "$canceled",
+
+      # Optional Fields
+      "$reason"           : "$payment_risk",
+      "$source"           : "$manual_review",
+      "$analyst"          : "someone@your-site.com",
+      "$webhook_id"       : "3ff1082a4aea8d0c58e3643ddb7a5bb87ffffeb2492dca33",
+      "$description"      : "Canceling because multiple fraudulent users on device",
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$order_status", order_properties)
+      
+  def remove_item_from_cart(self):
+    # Sample $remove_item_from_cart event
+    remove_item_from_cart_properties = {
+      # Required Fields
+      "$user_id"    : self.user_id,
+
+      # Supported Fields
+      "$session_id" : "gigtleqddo84l8cm15qe4il",
+      "$item"       : {
+        "$item_id"        : "B004834GQO",
+        "$product_title"  : "The Slanket Blanket-Texas Tea",
+        "$price"          : 39990000, # $39.99
+        "$currency_code"  : "USD",
+        "$quantity"       : 2,
+        "$upc"            : "6786211451001",
+        "$sku"            : "004834GQ",
+        "$brand"          : "Slanket",
+        "$manufacturer"   : "Slanket",
+        "$category"       : "Blankets & Throws",
+        "$tags"           : ["Awesome", "Wintertime specials"],
+        "$color"          : "Texas Tea"
+      },
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+
+    return self.client.track("$remove_item_from_cart", remove_item_from_cart_properties)
+      
+  def security_notification(self):
+    # Sample $security_notification event
+    security_notification_properties = {
+      # Required Fields
+      "$user_id"    : self.user_id,
+      "$session_id" : "gigtleqddo84l8cm15qe4il",
+      "$notification_status"     : "$sent",
+      # Optional fields if applicable
+      "$notification_type" : "$email",
+      "$notified_value"    : "billy123@domain.com",
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+
+    return self.client.track("$security_notification", security_notification_properties)
+
+  def transaction(self):
+    # Sample $transaction event
+    transaction_properties = {
+      # Required Fields
+      "$user_id"          : self.user_id,
+      "$amount"           : 506790000, # $506.79
+      "$currency_code"    : "USD",
+      # Supported Fields
+      "$user_email"                : self.user_email,
+      "$verification_phone_number" : "+123456789012",
+      "$transaction_type"          : "$sale",
+      "$transaction_status"        : "$failure",
+      "$decline_category"          : "$bank_decline",
+      "$order_id"                  : "ORDER-123124124",
+      "$transaction_id"            : "719637215",
+      "$billing_address"  : { # or "$sent_address" # or "$received_address"
+        "$name"         : "Bill Jones",
+        "$phone"        : "1-415-555-6041",
+        "$address_1"    : "2100 Main Street",
+        "$address_2"    : "Apt 3B",
+        "$city"         : "New London",
+        "$region"       : "New Hampshire",
+        "$country"      : "US",
+        "$zipcode"      : "03257"
+      },
+      "$brand_name"   : "sift",
+      "$site_domain"  : "sift.com",
+      "$site_country" : "US",
+      "$ordered_from" : {
+        "$store_id"      : "123",
+        "$store_address" : {
+          "$name"       : "Bill Jones",
+          "$phone"      : "1-415-555-6040",
+          "$address_1"  : "2100 Main Street",
+          "$address_2"  : "Apt 3B",
+          "$city"       : "New London",
+          "$region"     : "New Hampshire",
+          "$country"    : "US",
+          "$zipcode"    : "03257"
+        }
+      },
+      # Credit card example
+      "$payment_method"   : {
+          "$payment_type"    : "$credit_card",
+          "$payment_gateway" : "$braintree",
+          "$card_bin"        : "542486",
+          "$card_last4"      : "4444"
+      },
+      
+      # Supported fields for 3DS
+      "$status_3ds"                     : "$attempted",
+      "$triggered_3ds"                  : "$processor",
+      "$merchant_initiated_transaction" : False,
+
+      # Supported Fields
+      "$shipping_address" : {
+        "$name"         : "Bill Jones",
+        "$phone"        : "1-415-555-6041",
+        "$address_1"    : "2100 Main Street",
+        "$address_2"    : "Apt 3B",
+        "$city"         : "New London",
+        "$region"       : "New Hampshire",
+        "$country"      : "US",
+        "$zipcode"      : "03257"
+      },
+      "$session_id"       : "gigtleqddo84l8cm15qe4il",
+
+      # For marketplaces, use $seller_user_id to identify the seller
+      "$seller_user_id"     : "slinkys_emporium",
+
+      # Sample Custom Fields
+      "digital_wallet"      : "apple_pay", # "google_wallet", etc.
+      "coupon_code"         : "dollarMadness",
+      "shipping_choice"     : "FedEx Ground Courier",
+      "is_first_time_buyer" : False,
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+    return self.client.track("$transaction", transaction_properties)
+    
+  def update_account(self):
+    # Sample $update_account event
+    update_account_properties = {
+      # Required Fields
+      "$user_id"    : self.user_id,
+
+      # Supported Fields
+      "$changed_password"          : True,
+      "$user_email"                : self.user_email,
+      "$verification_phone_number" : "+123456789012",
+      "$name"                      : "Bill Jones",
+      "$phone"                     : "1-415-555-6040",
+      "$referrer_user_id"          : "janejane102",
+      "$payment_methods"  : [
+        {
+          "$payment_type"    : "$credit_card",
+          "$card_bin"        : "542486",
+          "$card_last4"      : "4444"
+        }
+      ],
+      "$billing_address"  :
+      {
+        "$name"         : "Bill Jones",
+        "$phone"        : "1-415-555-6041",
+        "$address_1"    : "2100 Main Street",
+        "$address_2"    : "Apt 3B",
+        "$city"         : "New London",
+        "$region"       : "New Hampshire",
+        "$country"      : "US",
+        "$zipcode"      : "03257"
+      },
+      "$shipping_address" : {
+        "$name"         : "Bill Jones",
+        "$phone"        : "1-415-555-6041",
+        "$address_1"    : "2100 Main Street",
+        "$address_2"    : "Apt 3B",
+        "$city"         : "New London",
+        "$region"       : "New Hampshire",
+        "$country"      : "US",
+        "$zipcode"      : "03257"
+      },
+
+      "$social_sign_on_type"   : "$twitter",
+      "$account_types"          : ["merchant", "premium"],
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+
+    return self.client.track("$update_account", update_account_properties)
+      
+  def update_content_comment(self):
+  # Sample $update_content event for comments
+    update_content_comment_properties = {
+      # Required fields
+      "$user_id"                : self.user_id,
+      "$content_id"             : "comment-23412",
+
+      # Recommended fields
+      "$session_id"             : "a234ksjfgn435sfg",
+      "$status"                 : "$active",
+      "$ip"                     : "255.255.255.0",
+
+      # Required $comment object
+      "$comment"                : {
+        "$body"               : "Congrats on the new role!",
+        "$contact_email"      : "alex_301@domain.com",
+        "$parent_comment_id"  : "comment-23407",
+        "$root_content_id"    : "listing-12923213",
+        "$images"             : [
+          {
+            "$md5_hash"       : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"           : "https://www.domain.com/file.png",
+            "$description"    : "An old picture"
+          }
+        ]
+      },
+      # Send this information from an APP client.
+      "$app"        : {
+        # Example for the iOS Calculator app.
+        "$os"                  : "iOS",
+        "$os_version"          : "10.1.3",
+        "$device_manufacturer" : "Apple",
+        "$device_model"        : "iPhone 4,2",
+        "$device_unique_id"    : "A3D261E4-DE0A-470B-9E4A-720F3D3D22E6",
+        "$app_name"            : "Calculator",
+        "$app_version"         : "3.2.7",
+        "$client_language"     : "en-US"
+      }
+    } 
+    return self.client.track("$update_content", update_content_comment_properties)
+      
+  def update_content_listing(self):
+    # Sample $update_content event for listings
+    update_content_listing_properties = {
+      # Required fields
+      "$user_id"                : self.user_id,
+      "$content_id"             : "listing-23412",
+
+      # Recommended fields
+      "$session_id"             : "a234ksjfgn435sfg",
+      "$status"                 : "$active",
+      "$ip"                     : "255.255.255.0",
+
+      # Required $listing object
+      "$listing"                : {
+        "$subject"            : "2 Bedroom Apartment for Rent",
+        "$body"               : "Capitol Hill Seattle brand new condo. 2 bedrooms and 1 full bath.",
+        "$contact_email"      : "alex_301@domain.com",
+        "$contact_address"    : {
+          "$name"           : "Bill Jones",
+          "$phone"          : "1-415-555-6041",
+          "$city"           : "New London",
+          "$region"         : "New Hampshire",
+          "$country"        : "US",
+          "$zipcode"        : "03257"
+        },
+        "$locations"          : [
+          {
+            "$city"           : "Seattle",
+            "$region"         : "Washington",
+            "$country"        : "US",
+            "$zipcode"        : "98112"
+          }
+        ],
+        "$listed_items"       : [
+          {
+            "$price"          : 2950000000, # $2950.00
+            "$currency_code"  : "USD",
+            "$tags"           : ["heat", "washer/dryer"]
+          }
+        ],
+        "$images"             : [
+          {
+            "$md5_hash"       : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"           : "https://www.domain.com/file.png",
+            "$description"    : "Billy's picture"
+          }
+        ],
+        "$expiration_time"    : 1549063157000 # UNIX timestamp in milliseconds
+      },
+      # Send this information from an APP client.
+      "$app"        : {
+        # Example for the iOS Calculator app.
+        "$os"                  : "iOS",
+        "$os_version"          : "10.1.3",
+        "$device_manufacturer" : "Apple",
+        "$device_model"        : "iPhone 4,2",
+        "$device_unique_id"    : "A3D261E4-DE0A-470B-9E4A-720F3D3D22E6",
+        "$app_name"            : "Calculator",
+        "$app_version"         : "3.2.7",
+        "$client_language"     : "en-US"
+      }
+    }
+    return self.client.track("$update_content", update_content_listing_properties)
+      
+  def update_content_message(self):
+    # Sample $update_content event for messages
+    update_content_message_properties = {
+      # Required fields
+      "$user_id"                 : self.user_id,
+      "$content_id"              : "message-23412",
+
+      # Recommended fields
+      "$session_id"              : "a234ksjfgn435sfg",
+      "$status"                  : "$active",
+      "$ip"                      : "255.255.255.0",
+
+      # Required $message object
+      "$message"                 : {
+        "$body"                : "Lets meet at 5pm",
+        "$contact_email"       : "alex_301@domain.com",
+        "$recipient_user_ids"  : ["fy9h989sjphh71"],
+        "$images"              : [
+          {
+            "$md5_hash"        : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"            : "https://www.domain.com/file.png",
+            "$description"     : "My hike today!"
+          }
+        ]
+      },
+
+      # Send this information from a BROWSER client.
+      "$browser"      : {
+        "$user_agent" :  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+        "$accept_language"  : "en-US",
+        "$content_language" : "en-GB"
+      }
+    }
+
+    return self.client.track("$update_content", update_content_message_properties)
+      
+  def update_content_post(self):
+    # Sample $update_content event for posts
+    update_content_post_properties = {
+      # Required fields
+      "$user_id"              : self.user_id,
+      "$content_id"           : "post-23412",
+
+      # Recommended fields
+      "$session_id"           : "a234ksjfgn435sfg",
+      "$status"               : "$active",
+      "$ip"                   : "255.255.255.0",
+
+      # Required $post object
+      "$post"                 : {
+        "$subject"          : "My new apartment!",
+        "$body"             : "Moved into my new apartment yesterday.",
+        "$contact_email"    : "alex_301@domain.com",
+        "$contact_address"  : {
+            "$name"         : "Bill Jones",
+            "$city"         : "New London",
+            "$region"       : "New Hampshire",
+            "$country"      : "US",
+            "$zipcode"      : "03257"
+        },
+        "$locations"        : [
+          {
+            "$city"         : "Seattle",
+            "$region"       : "Washington",
+            "$country"      : "US",
+            "$zipcode"      : "98112"
+          }
+        ],
+        "$categories"       : ["Personal"],
+        "$images"           : [
+          {
+            "$md5_hash"     : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"         : "https://www.domain.com/file.png",
+            "$description"  : "View from the window!"
+          }
+        ],
+        "$expiration_time"  : 1549063157000 # UNIX timestamp in milliseconds
+      },
+      # Send this information from an APP client.
+      "$app"        : {
+        # Example for the iOS Calculator app.
+        "$os"                  : "iOS",
+        "$os_version"          : "10.1.3",
+        "$device_manufacturer" : "Apple",
+        "$device_model"        : "iPhone 4,2",
+        "$device_unique_id"    : "A3D261E4-DE0A-470B-9E4A-720F3D3D22E6",
+        "$app_name"            : "Calculator",
+        "$app_version"         : "3.2.7",
+        "$client_language"     : "en-US"
+      }
+    }
+    return self.client.track("$update_content", update_content_post_properties)
+  
+  def update_content_profile(self):
+    # Sample $update_content event for reviews
+    update_content_profile_properties = {
+      # Required fields
+      "$user_id"              : self.user_id,
+      "$content_id"           : "profile-23412",
+
+      # Recommended fields
+      "$session_id"           : "a234ksjfgn435sfg",
+      "$status"               : "$active",
+      "$ip"                   : "255.255.255.0",
+
+      # Required $profile object
+      "$profile"              : {
+        "$body"             : "Hi! My name is Alex and I just moved to New London!",
+        "$contact_email"    : "alex_301@domain.com",
+        "$contact_address"  : {
+          "$name"         : "Alex Smith",
+          "$phone"        : "1-415-555-6041",
+          "$city"         : "New London",
+          "$region"       : "New Hampshire",
+          "$country"      : "US",
+          "$zipcode"      : "03257"
+        },
+        "$images"           : [
+          {
+            "$md5_hash"     : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"         : "https://www.domain.com/file.png",
+            "$description"  : "Alex's picture"
+          }
+        ],
+        "$categories"       : [
+          "Friends",
+          "Long-term dating"
+        ]
+      },
+      # =========================================
+      # Send this information from an APP client.
+      "$app"        : {
+        # Example for the iOS Calculator app.
+        "$os"                  : "iOS",
+        "$os_version"          : "10.1.3",
+        "$device_manufacturer" : "Apple",
+        "$device_model"        : "iPhone 4,2",
+        "$device_unique_id"    : "A3D261E4-DE0A-470B-9E4A-720F3D3D22E6",
+        "$app_name"            : "Calculator",
+        "$app_version"         : "3.2.7",
+        "$client_language"     : "en-US"
+      }
+    }
+    return self.client.track("$update_content", update_content_profile_properties)
+      
+  def update_content_review(self):
+    # Sample $update_content event for reviews
+    update_content_review_properties = {
+      # Required fields
+      "$user_id"                  : self.user_id,
+      "$content_id"               : "review-23412",
+
+      # Recommended fields
+      "$session_id"               : "a234ksjfgn435sfg",
+      "$status"                   : "$active",
+      "$ip"                       : "255.255.255.0",
+
+      # Required $review object
+      "$review"                   : {
+        "$subject"              : "Amazing Tacos!",
+        "$body"                 : "I ate the tacos.",
+        "$contact_email"        : "alex_301@domain.com",
+        "$locations"            : [
+          {
+            "$city"             : "Seattle",
+            "$region"           : "Washington",
+            "$country"          : "US",
+            "$zipcode"          : "98112"
+          }
+        ],
+        "$reviewed_content_id"  : "listing-234234",
+        "$images"               : [
+          {
+            "$md5_hash"         : "0cc175b9c0f1b6a831c399e269772661",
+            "$link"             : "https://www.domain.com/file.png",
+            "$description"      : "Calamari tacos."
+          }
+        ],
+        "$rating" : 4.5
+      },
+      # Send this information from an APP client.
+      "$app"        : {
+        # Example for the iOS Calculator app.
+        "$os"                  : "iOS",
+        "$os_version"          : "10.1.3",
+        "$device_manufacturer" : "Apple",
+        "$device_model"        : "iPhone 4,2",
+        "$device_unique_id"    : "A3D261E4-DE0A-470B-9E4A-720F3D3D22E6",
+        "$app_name"            : "Calculator",
+        "$app_version"         : "3.2.7",
+        "$client_language"     : "en-US"
+      }
+    }
+    return self.client.track("$update_content", update_content_review_properties)
+
+  def update_order(self):
+    # Sample $update_order event
+    update_order_properties = {
+      # Required Fields
+      "$user_id"          : self.user_id,
+      # Supported Fields
+      "$session_id"                : "gigtleqddo84l8cm15qe4il",
+      "$order_id"                  : "ORDER-28168441",
+      "$user_email"                : self.user_email,
+      "$verification_phone_number" : "+123456789012",
+      "$amount"           : 115940000, # $115.94
+      "$currency_code"    : "USD",
+      "$billing_address"  : {
+        "$name"         : "Bill Jones",
+        "$phone"        : "1-415-555-6041",
+        "$address_1"    : "2100 Main Street",
+        "$address_2"    : "Apt 3B",
+        "$city"         : "New London",
+        "$region"       : "New Hampshire",
+        "$country"      : "US",
+        "$zipcode"      : "03257"
+      },
+      "$payment_methods"  : [
+        {
+          "$payment_type"    : "$credit_card",
+          "$payment_gateway" : "$braintree",
+          "$card_bin"        : "542486",
+          "$card_last4"      : "4444"
+        }
+      ],
+      "$brand_name"   : "sift",
+      "$site_domain"  : "sift.com",
+      "$site_country" : "US",
+      "$ordered_from" : {
+        "$store_id"      : "123",
+        "$store_address" : {
+          "$name"       : "Bill Jones",
+          "$phone"      : "1-415-555-6040",
+          "$address_1"  : "2100 Main Street",
+          "$address_2"  : "Apt 3B",
+          "$city"       : "New London",
+          "$region"     : "New Hampshire",
+          "$country"    : "US",
+          "$zipcode"    : "03257"
+        }
+      },
+      "$shipping_address"  : {
+        "$name"          : "Bill Jones",
+        "$phone"         : "1-415-555-6041",
+        "$address_1"     : "2100 Main Street",
+        "$address_2"     : "Apt 3B",
+        "$city"          : "New London",
+        "$region"        : "New Hampshire",
+        "$country"       : "US",
+        "$zipcode"       : "03257"
+      },
+      "$expedited_shipping"       : True,
+      "$shipping_method"          : "$physical",
+      "$shipping_carrier"         : "UPS",
+      "$shipping_tracking_numbers": ["1Z204E380338943508", "1Z204E380338943509"],
+      "$items"                    : [
+        {
+          "$item_id"        : "12344321",
+          "$product_title"  : "Microwavable Kettle Corn: Original Flavor",
+          "$price"          : 4990000, # $4.99
+          "$upc"            : "097564307560",
+          "$sku"            : "03586005",
+          "$brand"          : "Peters Kettle Corn",
+          "$manufacturer"   : "Peters Kettle Corn",
+          "$category"       : "Food and Grocery",
+          "$tags"           : ["Popcorn", "Snacks", "On Sale"],
+          "$quantity"       : 4
+        },
+        {
+          "$item_id"        : "B004834GQO",
+          "$product_title"  : "The Slanket Blanket-Texas Tea",
+          "$price"          : 39990000, # $39.99
+          "$upc"            : "6786211451001",
+          "$sku"            : "004834GQ",
+          "$brand"          : "Slanket",
+          "$manufacturer"   : "Slanket",
+          "$category"       : "Blankets & Throws",
+          "$tags"           : ["Awesome", "Wintertime specials"],
+          "$color"          : "Texas Tea",
+          "$quantity"       : 2
+        }
+      ],
+      # For marketplaces, use $seller_user_id to identify the seller
+      "$seller_user_id"     : "slinkys_emporium",
+
+      "$promotions"         : [
+        {
+          "$promotion_id" : "FirstTimeBuyer",
+          "$status"       : "$success",
+          "$description"  : "$5 off",
+          "$discount"     : {
+            "$amount"                   : 5000000,  # $5.00
+            "$currency_code"            : "USD",
+            "$minimum_purchase_amount"  : 25000000  # $25.00
+          }
+        }
+      ],
+
+      # Sample Custom Fields
+      "digital_wallet"      : "apple_pay", # "google_wallet", etc.
+      "coupon_code"         : "dollarMadness",
+      "shipping_choice"     : "FedEx Ground Courier",
+      "is_first_time_buyer" : False,
+      # Send this information from an APP client.
+      "$app"        : {
+        # Example for the iOS Calculator app.
+        "$os"                  : "iOS",
+        "$os_version"          : "10.1.3",
+        "$device_manufacturer" : "Apple",
+        "$device_model"        : "iPhone 4,2",
+        "$device_unique_id"    : "A3D261E4-DE0A-470B-9E4A-720F3D3D22E6",
+        "$app_name"            : "Calculator",
+        "$app_version"         : "3.2.7",
+        "$client_language"     : "en-US"
+      }
+    }
+    return self.client.track("$update_order", update_order_properties)
+
+  def update_password(self):
+    # Sample $update_password event
+    update_password_properties = {
+      # Required Fields
+      "$user_id"       : self.user_id,
+      "$session_id"    : "gigtleqddo84l8cm15qe4il",
+      "$status"        : "$success",
+      "$reason"        : "$forced_reset",
+      "$ip"            : "128.148.1.135",     # IP of the user that entered the new password after the old password was reset
+      # Send this information from an APP client.
+      "$app"        : {
+        # Example for the iOS Calculator app.
+        "$os"                  : "iOS",
+        "$os_version"          : "10.1.3",
+        "$device_manufacturer" : "Apple",
+        "$device_model"        : "iPhone 4,2",
+        "$device_unique_id"    : "A3D261E4-DE0A-470B-9E4A-720F3D3D22E6",
+        "$app_name"            : "Calculator",
+        "$app_version"         : "3.2.7",
+        "$client_language"     : "en-US"
+      }
+    }
+    return self.client.track("$update_password", update_password_properties)
+
+  def verification(self):
+    # Sample $verification event
+    verification_properties = {
+      # Required Fields
+      "$user_id"            : self.user_id,
+      "$session_id"         : "gigtleqddo84l8cm15qe4il",
+      "$status"             : "$pending",
+
+      # Optional fields if applicable
+      "$verified_event"     : "$login",
+      "$reason"             : "$automated_rule", 
+      "$verification_type"  : "$sms",
+      "$verified_value"     : "14155551212"
+    }
+    return self.client.track("$verification", verification_properties)
+  

--- a/test_integration_app/globals.py
+++ b/test_integration_app/globals.py
@@ -1,0 +1,4 @@
+def initialize(): 
+    global user_id, user_email
+    user_id = 'billy_jones_301'
+    user_email = 'billjones1@example.com'

--- a/test_integration_app/main.py
+++ b/test_integration_app/main.py
@@ -95,5 +95,7 @@ def runAllMethods():
     assert (objUtils.isOK(objPSPMerchant.get_merchant_profiles()) == True)
     assert (objUtils.isOK(objPSPMerchant.get_merchant_profiles(batch_size=10, batch_token=None)) == True)
     print("PSP Merchant API Tested")
+    
+    print("Execution completed")
 
 runAllMethods()

--- a/test_integration_app/main.py
+++ b/test_integration_app/main.py
@@ -1,0 +1,99 @@
+from events_api import test_events_api
+from decisions_api import test_decisions_api
+from workflows_api import test_workflows_api
+from score_api import test_score_api
+from verifications_api import test_verification_api
+from psp_merchant_api import test_psp_merchant_api
+
+class Utils:
+    def isOK(self, response):
+        if(hasattr(response, 'status')):
+            return ((response.status == 0) and ((response.http_status_code == 200) or (response.http_status_code == 201)))
+        else:
+            return ((response.http_status_code == 200) or (response.http_status_code == 201))
+    
+def runAllMethods():
+    objUtils = Utils()
+    objEvents = test_events_api.EventsAPI()
+    objDecision = test_decisions_api.DecisionAPI()
+    objScore = test_score_api.ScoreAPI()
+    objWorkflow = test_workflows_api.WorkflowsAPI()
+    objVerification = test_verification_api.VerificationAPI()
+    objPSPMerchant = test_psp_merchant_api.PSPMerchantAPI()
+
+    #Events APIs
+
+    assert (objUtils.isOK(objEvents.add_item_to_cart()) == True)
+    assert (objUtils.isOK(objEvents.add_promotion()) == True)
+    assert (objUtils.isOK(objEvents.chargeback()) == True)
+    assert (objUtils.isOK(objEvents.content_status()) == True)
+    assert (objUtils.isOK(objEvents.create_account()) == True)
+    assert (objUtils.isOK(objEvents.create_content_comment()) == True)
+    assert (objUtils.isOK(objEvents.create_content_listing()) == True)
+    assert (objUtils.isOK(objEvents.create_content_message()) == True)
+    assert (objUtils.isOK(objEvents.create_content_post()) == True)
+    assert (objUtils.isOK(objEvents.create_content_profile()) == True)
+    assert (objUtils.isOK(objEvents.create_content_review()) == True)
+    assert (objUtils.isOK(objEvents.create_order()) == True)
+    assert (objUtils.isOK(objEvents.flag_content()) == True)
+    assert (objUtils.isOK(objEvents.link_session_to_user()) == True)
+    assert (objUtils.isOK(objEvents.login()) == True)
+    assert (objUtils.isOK(objEvents.logout()) == True)
+    assert (objUtils.isOK(objEvents.order_status()) == True)
+    assert (objUtils.isOK(objEvents.remove_item_from_cart()) == True)
+    assert (objUtils.isOK(objEvents.security_notification()) == True)
+    assert (objUtils.isOK(objEvents.transaction()) == True)
+    assert (objUtils.isOK(objEvents.update_account()) == True)
+    assert (objUtils.isOK(objEvents.update_content_comment()) == True)
+    assert (objUtils.isOK(objEvents.update_content_listing()) == True)
+    assert (objUtils.isOK(objEvents.update_content_message()) == True)
+    assert (objUtils.isOK(objEvents.update_content_post()) == True)
+    assert (objUtils.isOK(objEvents.update_content_profile()) == True)
+    assert (objUtils.isOK(objEvents.update_content_review()) == True)
+    assert (objUtils.isOK(objEvents.update_order()) == True)
+    assert (objUtils.isOK(objEvents.update_password()) == True)
+    assert (objUtils.isOK(objEvents.verification()) == True)
+    print("Events API Tested")
+    
+    # Decision APIs
+
+    assert (objUtils.isOK(objDecision.apply_user_decision()) == False)
+    assert (objUtils.isOK(objDecision.apply_order_decision()) == False)
+    assert (objUtils.isOK(objDecision.apply_session_decision()) == False)
+    assert (objUtils.isOK(objDecision.apply_content_decision()) == False)
+    assert (objUtils.isOK(objDecision.get_user_decisions()) == True)
+    assert (objUtils.isOK(objDecision.get_order_decisions()) == True)
+    assert (objUtils.isOK(objDecision.get_content_decisions()) == True)
+    assert (objUtils.isOK(objDecision.get_session_decisions()) == True)
+    assert (objUtils.isOK(objDecision.get_decisions()) == True)
+    print("Decision API Tested")
+    
+    # Workflows APIs
+
+    assert (objUtils.isOK(objWorkflow.synchronous_workflows()) == True)
+    print("Workflow API Tested")
+    
+    # Score APIs
+
+    assert (objUtils.isOK(objScore.get_user_score()) == False)
+    print("Score API Tested")
+    
+    # Verification APIs
+
+    assert (objUtils.isOK(objVerification.send()) == True)
+    assert (objUtils.isOK(objVerification.resend()) == True)
+    checkResponse = objVerification.check()
+    assert (objUtils.isOK(checkResponse) == True)
+    assert (checkResponse.body["status"] == 50)
+    print("Verification API Tested")
+    
+    # PSP Merchant APIs
+
+    assert (objUtils.isOK(objPSPMerchant.create_merchant()) == True)
+    assert (objUtils.isOK(objPSPMerchant.edit_merchant()) == True)
+    assert (objUtils.isOK(objPSPMerchant.get_a_merchant_profile()) == True)
+    assert (objUtils.isOK(objPSPMerchant.get_merchant_profiles()) == True)
+    assert (objUtils.isOK(objPSPMerchant.get_merchant_profiles(batch_size=10, batch_token=None)) == True)
+    print("PSP Merchant API Tested")
+
+runAllMethods()

--- a/test_integration_app/psp_merchant_api/__init__.py
+++ b/test_integration_app/psp_merchant_api/__init__.py
@@ -1,0 +1,1 @@
+from psp_merchant_api import test_psp_merchant_api

--- a/test_integration_app/psp_merchant_api/test_psp_merchant_api.py
+++ b/test_integration_app/psp_merchant_api/test_psp_merchant_api.py
@@ -1,0 +1,70 @@
+import sift
+import string 
+import random # define the random module  
+
+from os import environ as env
+
+class PSPMerchantAPI():
+  # Get the value of API_KEY and ACCOUNT_ID from environment variable
+  api_key = env['API_KEY']
+  account_id = env['ACCOUNT_ID']
+
+  client = sift.Client(api_key = api_key, account_id = account_id)
+  
+  def create_merchant(self):
+    merchant_id = ''.join(random.choices(string.digits, k = 7))    
+    merchantProperties={
+      "id": 'merchant_id_' + merchant_id,
+      "name": "Wonderful Payments Inc.13",
+      "description": "Wonderful Payments payment provider.",
+      "address": {
+        "name": "Alany",
+        "address_1": "Big Payment blvd, 22",
+        "address_2": "apt, 8",
+        "city": "New Orleans",
+        "region": "NA",
+        "country": "US",
+        "zipcode": "76830",
+        "phone": "0394888320"
+      },
+      "category": "1002",
+      "service_level": "Platinum",
+      "status": "active",
+      "risk_profile": {
+        "level": "low",
+        "score": 10
+      }
+    }
+    return self.client.create_psp_merchant_profile(merchantProperties)
+    
+  def edit_merchant(self):
+    merchantProperties={
+      "id": "merchant_id_01013",
+      "name": "Wonderful Payments Inc.13 edit",
+      "description": "Wonderful Payments payment provider. edit",
+      "address": {
+        "name": "Alany",
+        "address_1": "Big Payment blvd, 22",
+        "address_2": "apt, 8",
+        "city": "New Orleans",
+        "region": "NA",
+        "country": "US",
+        "zipcode": "76830",
+        "phone": "0394888320"
+      },
+      "category": "1002",
+      "service_level": "Platinum",
+      "status": "active",
+      "risk_profile": {
+        "level": "low",
+        "score": 10
+      }
+    }
+    return self.client.update_psp_merchant_profile("merchant_id_01013", merchantProperties)
+
+  def get_a_merchant_profile(self):
+    return self.client.get_a_psp_merchant_profile("merchant_id_01013")
+
+  def get_merchant_profiles(self, batch_token = None, batch_size = None):
+    return self.client.get_psp_merchant_profiles(batch_token, batch_size)
+  

--- a/test_integration_app/score_api/__init__.py
+++ b/test_integration_app/score_api/__init__.py
@@ -1,0 +1,1 @@
+from score_api import test_score_api

--- a/test_integration_app/score_api/test_score_api.py
+++ b/test_integration_app/score_api/test_score_api.py
@@ -1,0 +1,14 @@
+import sift
+import globals
+
+from os import environ as env
+
+class ScoreAPI(): 
+  # Get the value of API_KEY from environment variable
+  api_key = env['API_KEY']
+  client = sift.Client(api_key = api_key)
+  globals.initialize()
+  user_id = globals.user_id
+  
+  def get_user_score(self):
+    return self.client.get_user_score(user_id = self.user_id, abuse_types=["payment_abuse", "promotion_abuse"])

--- a/test_integration_app/verifications_api/__init__.py
+++ b/test_integration_app/verifications_api/__init__.py
@@ -1,0 +1,1 @@
+from verifications_api import test_verification_api

--- a/test_integration_app/verifications_api/test_verification_api.py
+++ b/test_integration_app/verifications_api/test_verification_api.py
@@ -1,0 +1,52 @@
+import sift
+import globals
+
+from os import environ as env
+
+class VerificationAPI():
+    # Get the value of API_KEY from environment variable
+    api_key = env['API_KEY']
+    client = sift.Client(api_key = api_key)
+    globals.initialize()
+    user_id = globals.user_id
+    user_email = globals.user_email
+  
+    def send(self):
+        sendProperties = {
+            '$user_id': self.user_id,
+            '$send_to': self.user_email,
+            '$verification_type': '$email',
+            '$brand_name': 'MyTopBrand',
+            '$language': 'en',
+            '$site_country': 'IN',
+            '$event': {
+                '$session_id': 'SOME_SESSION_ID',
+                '$verified_event': '$login',
+                '$verified_entity_id': 'SOME_SESSION_ID',
+                '$reason': '$automated_rule',
+                '$ip': '192.168.1.1',
+                '$browser': {
+                    '$user_agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36',
+                    '$accept_language': 'en-US',
+                    '$content_language': 'en-GB'
+                }
+            }
+        }       
+        return self.client.verification_send(sendProperties)
+            
+    def resend(self):    
+        resendProperties = {
+            '$user_id': self.user_id,
+            '$verified_event': '$login',
+            '$verified_entity_id': 'SOME_SESSION_ID'
+        } 
+        return self.client.verification_resend(resendProperties)
+
+    def check(self):
+        checkProperties = {
+            '$user_id': self.user_id,
+            '$code': '123456',
+            '$verified_event': '$login',
+            '$verified_entity_id': "SOME_SESSION_ID"
+        }
+        return self.client.verification_check(checkProperties)

--- a/test_integration_app/workflows_api/__init__.py
+++ b/test_integration_app/workflows_api/__init__.py
@@ -1,0 +1,1 @@
+from workflows_api import test_workflows_api

--- a/test_integration_app/workflows_api/test_workflows_api.py
+++ b/test_integration_app/workflows_api/test_workflows_api.py
@@ -1,0 +1,20 @@
+import sift
+import globals
+from os import environ as env
+
+class WorkflowsAPI():
+    # Get the value of API_KEY from environment variable
+    api_key = env['API_KEY']
+    client = sift.Client(api_key = api_key)
+    globals.initialize()
+    user_id = globals.user_id
+    user_email = globals.user_email
+    
+    def synchronous_workflows(self):
+        properties = {
+            '$user_id'    : self.user_id,
+            '$user_email' : self.user_email
+        } 
+        return self.client.track('$create_order', properties, return_workflow_status=True, 
+                                return_route_info=True, abuse_types=['promo_abuse', 'content_abuse', 'payment_abuse'])
+        

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,7 +22,7 @@ def valid_transaction_properties():
         '$seller_user_id': '654321',
         '$amount': Decimal('1253200.0'),
         '$currency_code': 'USD',
-        '$time': int(datetime.datetime.now().strftime('%s')),
+        '$time': int(datetime.datetime.now().strftime('%S')),
         '$transaction_id': 'my_transaction_id',
         '$billing_name': 'Mike Snow',
         '$billing_bin': '411111',

--- a/tests/test_client_v203.py
+++ b/tests/test_client_v203.py
@@ -19,7 +19,7 @@ def valid_transaction_properties():
         '$seller_user_id': '654321',
         '$amount': Decimal('1253200.0'),
         '$currency_code': 'USD',
-        '$time': int(datetime.datetime.now().strftime('%s')),
+        '$time': int(datetime.datetime.now().strftime('%S')),
         '$transaction_id': 'my_transaction_id',
         '$billing_name': 'Mike Snow',
         '$billing_bin': '411111',


### PR DESCRIPTION
## Purpose
Currently, we don’t perform any thorough testing before releasing sift-python lib. The idea of this task is to actually setup an integration app that is going to contain a set of tests we run against the lib before releasing it. Those tests should be performed against real Sift env (Sift prod account)

This integration app can be a representative template for other libs - eventually we want to have the same integration app for every single public lib we support
## Summary
Methods created for Events, Decisions, Workflows, Score, Verification and PSP Merchant API
## Testing
Methods are implemented and tested manually
## Checklist
- [x] The change was thoroughly tested manually
- [ ] The change was covered with unit tests
- [x] The change was tested with real API calls (if applicable)
- [x] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README
