### PR TITLE
Updating setup.py to work with python 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,20 @@
-import imp
+try:
+    from imp import load_source
+except ImportError:
+    import importlib.util
+    import importlib.machinery
+
+    def load_source(modname, filename):
+        loader = importlib.machinery.SourceFileLoader(modname, filename)
+        spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+        module = importlib.util.module_from_spec(spec)
+        # The module is always executed and not cached in sys.modules.
+        # Uncomment the following line to cache the module.
+        # sys.modules[module.__name__] = module
+        loader.exec_module(module)
+        return module
+
+
 import os
 
 try:
@@ -16,8 +32,8 @@ except Exception:
     README = ''
     CHANGES = ''
 
-# Use imp to avoid sift/__init__.py
-version_mod = imp.load_source('__tmp', os.path.join(here, 'sift/version.py'))
+# Use imp/importlib to avoid sift/__init__.py
+version_mod = load_source('__tmp', os.path.join(here, 'sift/version.py'))
 
 setup(
     name='Sift',


### PR DESCRIPTION
## Purpose
Fix https://github.com/SiftScience/sift-python/issues/102
## Summary
Followed the instructions at https://docs.python.org/3.12/whatsnew/3.12.html#imp
## Testing
I was able to install the module in python 3.12 when checked out locally with my branch.
## Checklist
- [X] The change was thoroughly tested manually
- [ ] The change was covered with unit tests
- [X] The change was tested with real API calls (if applicable)
- [ ] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README
