### PR TITLE
Release 5.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+5.6.0 2024-05-31
+- Added support for a `warnings` value in the `fields` query parameter
+
 5.5.1 2024-02-22
 - Support for Python 3.12
 

--- a/sift/version.py
+++ b/sift/version.py
@@ -1,2 +1,2 @@
-VERSION = '5.5.1'
+VERSION = '5.6.0'
 API_VERSION = '205'


### PR DESCRIPTION
Release 5.6.0 - Added support for a `warnings` value in the `fields` query parameter
https://github.com/SiftScience/sift-python/pull/110