### PR TITLE
[API-7827]: Stop using url parameters to authenticate Score API requests

### DIFF
--- a/sift/client.py
+++ b/sift/client.py
@@ -328,7 +328,7 @@ class Client(object):
 
         url = self._user_score_url(user_id, self.version)
         headers = {'User-Agent': self._user_agent()}
-        params = {'api_key': self.api_key}
+        params = {}
         if abuse_types:
             params['abuse_types'] = ','.join(abuse_types)
 
@@ -337,7 +337,8 @@ class Client(object):
                 url,
                 headers=headers,
                 timeout=timeout,
-                params=params)
+                params=params,
+                auth=requests.auth.HTTPBasicAuth(self.api_key, ''))
             return Response(response)
         except requests.exceptions.RequestException as e:
             raise ApiException(str(e), url)

--- a/sift/client.py
+++ b/sift/client.py
@@ -235,7 +235,7 @@ class Client(object):
             version = self.version
 
         headers = {'User-Agent': self._user_agent()}
-        params = {'api_key': self.api_key}
+        params = {}
         if abuse_types:
             params['abuse_types'] = ','.join(abuse_types)
 
@@ -249,7 +249,8 @@ class Client(object):
                 url,
                 headers=headers,
                 timeout=timeout,
-                params=params)
+                params=params,
+                auth=HTTPBasicAuth(self.api_key, ''))
             return Response(response)
         except requests.exceptions.RequestException as e:
             raise ApiException(str(e), url)

--- a/sift/client.py
+++ b/sift/client.py
@@ -7,6 +7,7 @@ import json
 import requests
 import requests.auth
 import sys
+from requests.auth import HTTPBasicAuth
 
 if sys.version_info[0] < 3:
     import six.moves.urllib as urllib
@@ -284,7 +285,7 @@ class Client(object):
 
         url = self._user_score_url(user_id, self.version)
         headers = {'User-Agent': self._user_agent()}
-        params = {'api_key': self.api_key}
+        params = {}
         if abuse_types:
             params['abuse_types'] = ','.join(abuse_types)
 
@@ -296,7 +297,8 @@ class Client(object):
                 url,
                 headers=headers,
                 timeout=timeout,
-                params=params)
+                params=params,
+                auth=HTTPBasicAuth(self.api_key, ''))
             return Response(response)
         except requests.exceptions.RequestException as e:
             raise ApiException(str(e), url)

--- a/sift/client.py
+++ b/sift/client.py
@@ -404,7 +404,7 @@ class Client(object):
 
         url = self._label_url(user_id, version)
         headers = {'User-Agent': self._user_agent()}
-        params = {'api_key': self.api_key}
+        params = {}
         if abuse_type:
             params['abuse_type'] = abuse_type
 
@@ -413,7 +413,8 @@ class Client(object):
                 url,
                 headers=headers,
                 timeout=timeout,
-                params=params)
+                params=params,
+                auth=requests.auth.HTTPBasicAuth(self.api_key, ''))
             return Response(response)
 
         except requests.exceptions.RequestException as e:

--- a/sift/client.py
+++ b/sift/client.py
@@ -7,7 +7,6 @@ import json
 import requests
 import requests.auth
 import sys
-from requests.auth import HTTPBasicAuth
 
 if sys.version_info[0] < 3:
     import six.moves.urllib as urllib
@@ -250,7 +249,7 @@ class Client(object):
                 headers=headers,
                 timeout=timeout,
                 params=params,
-                auth=HTTPBasicAuth(self.api_key, ''))
+                auth=requests.auth.HTTPBasicAuth(self.api_key, ''))
             return Response(response)
         except requests.exceptions.RequestException as e:
             raise ApiException(str(e), url)
@@ -299,7 +298,7 @@ class Client(object):
                 headers=headers,
                 timeout=timeout,
                 params=params,
-                auth=HTTPBasicAuth(self.api_key, ''))
+                auth=requests.auth.HTTPBasicAuth(self.api_key, ''))
             return Response(response)
         except requests.exceptions.RequestException as e:
             raise ApiException(str(e), url)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import sys
 import unittest
 import warnings
 from decimal import Decimal
+from requests.auth import HTTPBasicAuth
 
 import mock
 import requests.exceptions
@@ -388,9 +389,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.get_user_score('12345', test_timeout)
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/users/12345/score',
-                params={'api_key': self.test_key},
+                params={},
                 headers=mock.ANY,
-                timeout=test_timeout)
+                timeout=test_timeout,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")
@@ -415,9 +417,10 @@ class TestSiftPythonClient(unittest.TestCase):
                                                        timeout=test_timeout)
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/users/12345/score',
-                params={'api_key': self.test_key, 'abuse_types': 'payment_abuse,content_abuse'},
+                params={'abuse_types': 'payment_abuse,content_abuse'},
                 headers=mock.ANY,
-                timeout=test_timeout)
+                timeout=test_timeout,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")
@@ -1488,9 +1491,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.get_user_score(user_id='12345', timeout=test_timeout, include_score_percentiles=True)
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/users/12345/score',
-                params={'api_key': self.test_key, 'fields': 'SCORE_PERCENTILES'},
+                params={'fields': 'SCORE_PERCENTILES'},
                 headers=mock.ANY,
-                timeout=test_timeout)
+                timeout=test_timeout,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -975,7 +975,8 @@ class TestSiftPythonClient(unittest.TestCase):
                 'https://api.siftscience.com/v205/users/%s/labels' % user_id,
                 headers=mock.ANY,
                 timeout=mock.ANY,
-                params={'api_key': self.test_key, 'abuse_type': 'account_abuse'})
+                params={'abuse_type': 'account_abuse'},
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
 
@@ -1015,7 +1016,8 @@ class TestSiftPythonClient(unittest.TestCase):
                 'https://api.siftscience.com/v205/users/%s/labels' % urllib.parse.quote(user_id),
                 headers=mock.ANY,
                 timeout=mock.ANY,
-                params={'api_key': self.test_key})
+                params={},
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -343,9 +343,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.score('12345')
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/score/12345',
-                params={'api_key': self.test_key},
+                params={},
                 headers=mock.ANY,
-                timeout=mock.ANY)
+                timeout=mock.ANY,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")
@@ -365,9 +366,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.score('12345', test_timeout)
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/score/12345',
-                params={'api_key': self.test_key},
+                params={},
                 headers=mock.ANY,
-                timeout=test_timeout)
+                timeout=test_timeout,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")
@@ -1058,9 +1060,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.score(user_id, abuse_types=['legacy'])
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/score/%s' % urllib.parse.quote(user_id),
-                params={'api_key': self.test_key, 'abuse_types': 'legacy'},
+                params={'abuse_types': 'legacy'},
                 headers=mock.ANY,
-                timeout=mock.ANY)
+                timeout=mock.ANY,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")
@@ -1467,9 +1470,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.score(user_id='12345', include_score_percentiles=True)
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v205/score/12345',
-                params={'api_key': self.test_key, 'fields': 'SCORE_PERCENTILES'},
+                params={'fields': 'SCORE_PERCENTILES'},
                 headers=mock.ANY,
-                timeout=mock.ANY)
+                timeout=mock.ANY,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -445,9 +445,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.rescore_user('12345', test_timeout)
             mock_post.assert_called_with(
                 'https://api.siftscience.com/v205/users/12345/score',
-                params={'api_key': self.test_key},
+                params={},
                 headers=mock.ANY,
-                timeout=test_timeout)
+                timeout=test_timeout,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")
@@ -472,9 +473,10 @@ class TestSiftPythonClient(unittest.TestCase):
                                                      timeout=test_timeout)
             mock_post.assert_called_with(
                 'https://api.siftscience.com/v205/users/12345/score',
-                params={'api_key': self.test_key, 'abuse_types': 'payment_abuse,content_abuse'},
+                params={'abuse_types': 'payment_abuse,content_abuse'},
                 headers=mock.ANY,
-                timeout=test_timeout)
+                timeout=test_timeout,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert (response.is_ok())
             assert (response.api_error_message == "OK")

--- a/tests/test_client_v203.py
+++ b/tests/test_client_v203.py
@@ -288,7 +288,8 @@ class TestSiftPythonClient(unittest.TestCase):
                 'https://api.siftscience.com/v203/users/%s/labels' % user_id,
                 headers=mock.ANY,
                 timeout=mock.ANY,
-                params={'api_key': self.test_key})
+                params={},
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert(response.is_ok())
 
@@ -329,7 +330,8 @@ class TestSiftPythonClient(unittest.TestCase):
                 'https://api.siftscience.com/v203/users/%s/labels' % urllib.parse.quote(user_id),
                 headers=mock.ANY,
                 timeout=mock.ANY,
-                params={'api_key': self.test_key})
+                params={},
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert(response.is_ok())
 

--- a/tests/test_client_v203.py
+++ b/tests/test_client_v203.py
@@ -7,6 +7,7 @@ import sift
 import unittest
 import sys
 import requests.exceptions
+from requests.auth import HTTPBasicAuth
 if sys.version_info[0] < 3:
     import six.moves.urllib as urllib 
 else:
@@ -166,9 +167,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client_v204.score('12345', version='203')
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v203/score/12345',
-                params={'api_key': self.test_key},
+                params={},
                 headers=mock.ANY,
-                timeout=mock.ANY)
+                timeout=mock.ANY,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert(response.is_ok())
             assert(response.api_error_message == "OK")
@@ -186,9 +188,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.score('12345', test_timeout)
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v203/score/12345',
-                params={'api_key': self.test_key},
+                params={},
                 headers=mock.ANY,
-                timeout=test_timeout)
+                timeout=test_timeout,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert(response.is_ok())
             assert(response.api_error_message == "OK")
@@ -373,9 +376,10 @@ class TestSiftPythonClient(unittest.TestCase):
             response = self.sift_client.score(user_id)
             mock_get.assert_called_with(
                 'https://api.siftscience.com/v203/score/%s' % urllib.parse.quote(user_id),
-                params={'api_key': self.test_key},
+                params={},
                 headers=mock.ANY,
-                timeout=mock.ANY)
+                timeout=mock.ANY,
+                auth=HTTPBasicAuth(self.test_key, ''))
             self.assertIsInstance(response, sift.client.Response)
             assert(response.is_ok())
             assert(response.api_error_message == "OK")


### PR DESCRIPTION
## Purpose
- Stop using url parameters to authenticate Score API requests
- https://sift.atlassian.net/browse/API-7827

## Summary
Call Sift endpoints with Basic Authentication instead of sending `api_key` as a request parameter.
Applied to the following calls:
Anthropic raised a concern about our sift-python SDK logging api keys when an exception occurs. This affects these calls:
- Score (`client.score()` in sift-python)
- Get Score (`client.get_user_score()` )
- Rescore User (`client.rescore_user()`)
- Unlabel (`client.unlabel()`)

## Testing
- Unit Tests 
- Integration testing app

## Checklist
- [ ] The change was thoroughly tested manually
- [ ] The change was covered with unit tests
- [ ] The change was tested with real API calls (if applicable)
- [ ] Necessary changes were made in the integration tests (if applicable)
- [ ] New functionality is reflected in README
