### PR TITLE
Release 5.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+5.6.1 2024-10-08
+- Updated implementation to use Basic Authentication instead of passing `API_KEY` as a request parameter for the following calls:
+  - `client.score()`
+  - `client.get_user_score()`
+  - `client.rescore_user()`
+  - `client.unlabel()`
+
 5.6.0 2024-05-31
 - Added support for a `warnings` value in the `fields` query parameter
 

--- a/sift/version.py
+++ b/sift/version.py
@@ -1,2 +1,2 @@
-VERSION = '5.6.0'
+VERSION = '5.6.1'
 API_VERSION = '205'


### PR DESCRIPTION
Release 5.6.1 - Updated implementation to use Basic Authentication instead of passing `API_KEY` as a request parameter for the following calls:
  - `client.score()`
  - `client.get_user_score()`
  - `client.rescore_user()`
  - `client.unlabel()`
https://github.com/SiftScience/sift-python/pull/114